### PR TITLE
Limit Page Width Vertical Videos Bug Fix

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -292,17 +292,31 @@ html[it-remove-related-search-results=true] li>div.search-refinements {
 ------------------------------------------------------------------------------*/
 
 html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #columns.ytd-watch-flexy,
-html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #primary.ytd-watch-flexy,
+html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #primary.ytd-watch-flexy
+{
+    max-width: 100% !important;
+}
+
 html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #player-container-outer.ytd-watch-flexy
 {
-    max-width: unset !important;
+    max-width: 100% !important;
+    max-height: var(--ytd-watch-flexy-max-player-height) !important;
+}
+
+html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #player-container-inner.ytd-watch-flexy
+{
+    padding-top: calc(var(--ytd-watch-flexy-max-player-height) + 45px )!important;
+}
+
+html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) #player
+{
+    padding-bottom: 45px !important;
 }
 
 html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) .html5-video-container
 {
-    display: flex !important;
-    justify-content: center !important;
-    align-items: center !important;
+    height: 100% !important;
+    width: 100% !important;
 }
 
 html[it-limit-page-width=false] ytd-watch-flexy:not([fullscreen]) video {


### PR DESCRIPTION
Fixes Limit Page Width so it doesn't break when watching a vertical or square aspect ratio video.
https://github.com/code-for-charity/YouTube-Extension/issues/1244

Appears to work without issue in both the regular player and the theater player.

Modify as you see fit.