### PR TITLE
Fix for fit_to_window and full_window

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -745,10 +745,17 @@ html[data-page-type=video][it-player-size='full_window'] {
     --it-player-size: 100vh;
 }
 
+html[data-page-type=video][it-player-size='full_window'] .ytp-fit-cover-video .html5-main-video{
+    object-fit:contain !important;
+}
+
 html[data-page-type=video][it-player-size='fit_to_window'] {
     --it-player-size: 100vh;
 }
 
+html[data-page-type=video][it-player-size='fit_to_window'] .ytp-fit-cover-video .html5-main-video{
+    object-fit:contain !important;
+}
 
 /*------------------------------------------------------------------------------
 # ELEMENTS


### PR DESCRIPTION
Addresses  issues #1272 and #1278 caused by YouTube changing `<video>` tag to `object-fit:cover` instead of old `object-fit:containt`. Not sure if the CSS was put in the right category or if it should apply to other scaling modes.