### PR TITLE
Fix incorrect channel link for playlist

### DIFF
--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -3234,11 +3234,8 @@ ImprovedTube.channelDefaultTab = function (a) {
 
     if (option && option !== '/' && a.parentNode && a.parentNode.id !== 'contenteditable-root') {
         if (this.regex.channel_home_page.test(a.href) && !a.href.endsWith(option)) {
-            if (!a.dataset.itOrigin) {
-                a.dataset.itOrigin = a.href.replace(this.regex.channel_home_page_postfix, '');
-            }
 
-            a.href = a.dataset.itOrigin + option;
+            a.href = a.href.replace(this.regex.channel_home_page_postfix, '') + option;
 
             a.addEventListener('click', function (event) {
                 event.stopPropagation();


### PR DESCRIPTION
Fix "DEFAULT CHANNEL TAB" set incorrect channel link to video author when playlist play the next video in playlist.

Fix #1333