### PR TITLE
Revert removal of locales and updates es_419 with es

### DIFF
--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -1,0 +1,1070 @@
+{
+    "ARROWDOWN": {
+        "message": "⇩"
+    },
+    "ARROWLEFT": {
+        "message": "⇦"
+    },
+    "ARROWRIGHT": {
+        "message": "⇨"
+    },
+    "ARROWUP": {
+        "message": "⇧"
+    },
+    "about": {
+        "message": "About"
+    },
+    "accept": {
+        "message": "Accept"
+    },
+    "activate": {
+        "message": "Activate"
+    },
+    "activateCaptions": {
+        "message": "Activate captions"
+    },
+    "activateFullscreen": {
+        "message": "Activate fullscreen"
+    },
+    "activated": {
+        "message": "Activated"
+    },
+    "activatedFeatures": {
+        "message": "Activated features"
+    },
+    "activeFeatures": {
+        "message": "Active features"
+    },
+    "addScrollToTop": {
+        "message": "Add «Scroll to top»"
+    },
+    "ads": {
+        "message": "Ads"
+    },
+    "all": {
+        "message": "All"
+    },
+    "allow": {
+        "message": "Allow"
+    },
+    "allow60fps": {
+        "message": "Allow 60fps"
+    },
+    "always": {
+        "message": "Always"
+    },
+    "alwaysActive": {
+        "message": "Always active"
+    },
+    "alwaysShowProgressBar": {
+        "message": "Always show progress bar"
+    },
+    "amber": {
+        "message": "Amber"
+    },
+    "analyzer": {
+        "message": "Analyzer"
+    },
+    "appearance": {
+        "message": "Appearance"
+    },
+    "areYouSureYouWantToExportTheData": {
+        "message": "Are you sure you want to export the data?"
+    },
+    "areYouSureYouWantToImportTheData": {
+        "message": "Are you sure you want to import this data?"
+    },
+    "audio": {
+        "message": "Audio"
+    },
+    "audioFormats": {
+        "message": "Audio formats"
+    },
+    "auto": {
+        "message": "Auto"
+    },
+    "autoFullscreen": {
+        "message": "Auto-fullscreen"
+    },
+    "autopauseWhenSwitchingTabs": {
+        "message": "Autopause when switching tabs"
+    },
+    "autoplay": {
+        "message": "Autoplay"
+    },
+    "avoidAv1": {
+        "message": "Avoid AV1"
+    },
+    "avoidAv1Vp8Vp9": {
+        "message": "Avoid AV1, VP8, VP9"
+    },
+    "avoidAv1Vp9": {
+        "message": "Avoid AV1, VP9"
+    },
+    "avoidCpuRenderingWhenPossible": {
+        "message": "Avoid CPU rendering when possible"
+    },
+    "backgroundColor": {
+        "message": "Background color"
+    },
+    "backgroundOpacity": {
+        "message": "Background opacity"
+    },
+    "backupAndReset": {
+        "message": "Backup & reset"
+    },
+    "baseOnSystemColorScheme": {
+        "message": "Base on system color scheme"
+    },
+    "belowPlayer": {
+        "message": "Below player"
+    },
+    "black": {
+        "message": "Black"
+    },
+    "blacklist": {
+        "message": "Blacklist"
+    },
+    "blockAll": {
+        "message": "Block all"
+    },
+    "blockAv1": {
+        "message": "Block AV1"
+    },
+    "blockH264": {
+        "message": "Block H.264"
+    },
+    "blockMusic": {
+        "message": "Block music"
+    },
+    "blockVp8": {
+        "message": "Block VP8"
+    },
+    "blockVp9": {
+        "message": "Block VP9"
+    },
+    "blue": {
+        "message": "Blue"
+    },
+    "blueGray": {
+        "message": "Blue gray"
+    },
+    "bluelight": {
+        "message": "Bluelight"
+    },
+    "brown": {
+        "message": "Brown"
+    },
+    "browser": {
+        "message": "Browser"
+    },
+    "browserVersion": {
+        "message": "Browser version"
+    },
+    "bubbles": {
+        "message": "Bubbles"
+    },
+    "bug": {
+        "message": "Bug"
+    },
+    "buttons": {
+        "message": "Buttons"
+    },
+    "cancel": {
+        "message": "Cancel"
+    },
+    "categories": {
+        "message": "Categories"
+    },
+    "channel": {
+        "message": "Channel"
+    },
+    "channels": {
+        "message": "Channels"
+    },
+    "characterEdgeStyle": {
+        "message": "Character edge style"
+    },
+    "clip": {
+        "message": "Clip"
+    },
+    "clipboard": {
+        "message": "Clipboard"
+    },
+    "codecH264": {
+        "message": "Codec h.264"
+    },
+    "codecs": {
+        "message": "Codecs"
+    },
+    "collapseOfSubscriptionSections": {
+        "message": "Collapse of subscription sections"
+    },
+    "collapsed": {
+        "message": "Collapsed"
+    },
+    "comments": {
+        "message": "Comments"
+    },
+    "confirmationBeforeClosing": {
+        "message": "Confirmation before closing"
+    },
+    "cookies": {
+        "message": "Cookies"
+    },
+    "cores": {
+        "message": "Cores"
+    },
+    "cropChapterTitles": {
+        "message": "Crop chapter titles"
+    },
+    "custom": {
+        "message": "Custom"
+    },
+    "customCss": {
+        "message": "Custom CSS"
+    },
+    "customJs": {
+        "message": "Custom JS"
+    },
+    "customMiniPlayer": {
+        "message": "Custom Mini-Player"
+    },
+    "cyan": {
+        "message": "Cyan"
+    },
+    "dark": {
+        "message": "Dark"
+    },
+    "darkTheme": {
+        "message": "Dark theme"
+    },
+    "dateAndTime": {
+        "message": "Date & time"
+    },
+    "dawn": {
+        "message": "Dawn"
+    },
+    "decreasePlaybackSpeed": {
+        "message": "Decrease playback speed"
+    },
+    "decreaseVolume": {
+        "message": "Decrease volume"
+    },
+    "deepOrange": {
+        "message": "Deep orange"
+    },
+    "deepPurple": {
+        "message": "Deep purple"
+    },
+    "default": {
+        "message": "Default"
+    },
+    "defaultChannelTab": {
+        "message": "Default channel tab"
+    },
+    "defaultContentCountry": {
+        "message": "Default content country"
+    },
+    "deleteWatchedVideos": {
+        "message": "Delete watched videos"
+    },
+    "deleteYoutubeCookies": {
+        "message": "Delete YouTube cookies"
+    },
+    "depressed": {
+        "message": "Depressed"
+    },
+    "description": {
+        "message": "Description"
+    },
+    "description_ext": {
+        "message": "Make YouTube tidy+smart! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+    },
+    "desert": {
+        "message": "Desert"
+    },
+    "details": {
+        "message": "Details"
+    },
+    "developerOptions": {
+        "message": "Developer options"
+    },
+    "device": {
+        "message": "Device"
+    },
+    "dim": {
+        "message": "Dim"
+    },
+    "disabled": {
+        "message": "Disabled"
+    },
+    "dislike": {
+        "message": "Dislike"
+    },
+    "doNotChange": {
+        "message": "Don't change"
+    },
+    "donate": {
+        "message": "Donate"
+    },
+    "download": {
+        "message": "Download"
+    },
+    "draggable": {
+        "message": "Draggable"
+    },
+    "dropShadow": {
+        "message": "Drop shadow"
+    },
+    "durationWithSpeed": {
+        "message": "Show time remaining with reference to playback speed"
+    },
+    "email": {
+        "message": "Email"
+    },
+    "empty": {
+        "message": "Empty"
+    },
+    "enabled": {
+        "message": "Enabled"
+    },
+    "enabledForced": {
+        "message": "Enabled (forced)"
+    },
+    "expanded": {
+        "message": "Expanded"
+    },
+    "exportSettings": {
+        "message": "Export settings"
+    },
+    "extension": {
+        "message": "Extension"
+    },
+    "file": {
+        "message": "File"
+    },
+    "filters": {
+        "message": "Filters"
+    },
+    "fitToWindow": {
+        "message": "Fit to window"
+    },
+    "flash": {
+        "message": "Flash"
+    },
+    "font": {
+        "message": "Font"
+    },
+    "fontColor": {
+        "message": "Font color"
+    },
+    "fontFamily": {
+        "message": "Font family"
+    },
+    "fontOpacity": {
+        "message": "Font opacity"
+    },
+    "fontSize": {
+        "message": "Font size"
+    },
+    "footer": {
+        "message": "Footer"
+    },
+    "forceSDR": {
+        "message": "Force SDR"
+    },
+    "forcedPlayVideoFromTheBeginning": {
+        "message": "Force video to play from the beginning"
+    },
+    "forcedPlaybackSpeed": {
+        "message": "Forced playback speed"
+    },
+    "forcedTheaterMode": {
+        "message": "Forced theater mode"
+    },
+    "forcedVolume": {
+        "message": "Forced volume"
+    },
+    "foundABug": {
+        "message": "Found a bug?"
+    },
+    "fullWindow": {
+        "message": "Full window"
+    },
+    "general": {
+        "message": "General"
+    },
+    "geoPreference": {
+        "message": "Geo Preference"
+    },
+    "github": {
+        "message": "GitHub"
+    },
+    "goToSearchBox": {
+        "message": "Go to search box"
+    },
+    "googleApiKey": {
+        "message": "Google API key"
+    },
+    "gpu": {
+        "message": "GPU"
+    },
+    "green": {
+        "message": "Green"
+    },
+    "hd": {
+        "message": "HD"
+    },
+    "hdThumbnail": {
+        "message": "HD thumbnail"
+    },
+    "header": {
+        "message": "Header"
+    },
+    "hidden": {
+        "message": "Hidden"
+    },
+    "hiddenOnVideoPage": {
+        "message": "Hidden on video page"
+    },
+    "hideAnimatedThumbnails": {
+        "message": "Hide animated thumbnails"
+    },
+    "hideAnnotations": {
+        "message": "Hide annotations"
+    },
+    "hideButtonLabel": {
+        "message": "Hide Button Label"
+    },
+    "hideCards": {
+        "message": "Hide cards"
+    },
+    "hideCountryCode": {
+        "message": "Hide country code"
+    },
+    "hideDate": {
+        "message": "Hide date"
+    },
+    "hideDetailButton": {
+        "message": "Hide Detail Button"
+    },
+    "hideDetails": {
+        "message": "Hide details"
+    },
+    "hideEndscreen": {
+        "message": "Hide endscreen"
+    },
+    "hideFeaturedContent": {
+        "message": "Hide featured content"
+    },
+    "hideFooter": {
+        "message": "Hide footer"
+    },
+    "hideGradientBottom": {
+        "message": "Hide shadow around player-bar"
+    },
+    "hidePlayerControlsBar": {
+        "message": "Hide player controls bar"
+    },
+    "hidePlayerControlsBarButtons": {
+        "message": "Hide player controls     buttons"
+    },
+    "hidePlayerControlsBarOptions": {
+        "message": "Hide player controls options"
+    },
+    "hidePlaylist": {
+        "message": "Hide playlist"
+    },
+    "hideRightButtons": {
+        "message": "Hide right buttons"
+    },
+    "hideScrollForDetails": {
+        "message": "Hide «Scroll for details»"
+    },
+    "hideSkipOverlay": {
+        "message": "Hide 5 second skip animation"
+    },
+    "hideThumbnailOverlay": {
+        "message": "Hide buttons on thumbnails"
+    },
+    "hideThumbnails": {
+        "message": "Hide thumbnails"
+    },
+    "hideViewsCount": {
+        "message": "Hide views count"
+    },
+    "hideVoiceSearchButton": {
+        "message": "Hide voice search button"
+    },
+    "high": {
+        "message": "High"
+    },
+    "history": {
+        "message": "History"
+    },
+    "home": {
+        "message": "Home"
+    },
+    "hover": {
+        "message": "Hover"
+    },
+    "hoverOnVideoPage": {
+        "message": "Hover on video page"
+    },
+    "howLongAgoTheVideoWasUploaded": {
+        "message": "How long ago the video was uploaded"
+    },
+    "icons": {
+        "message": "Icons"
+    },
+    "iconsOnly": {
+        "message": "Icons only"
+    },
+    "importSettings": {
+        "message": "Import settings"
+    },
+    "improveLogo": {
+        "message": "Improve logo"
+    },
+    "improvedtubeButtons": {
+        "message": "ImprovedTube buttons"
+    },
+    "improvedtubeIconOnYoutube": {
+        "message": "ImprovedTube icon on YouTube"
+    },
+    "improvedtubeLanguage": {
+        "message": "ImprovedTube language"
+    },
+    "improvedtubeVersion": {
+        "message": "ImprovedTube version"
+    },
+    "increasePlaybackSpeed": {
+        "message": "Increase playback speed"
+    },
+    "increaseVolume": {
+        "message": "Increase volume"
+    },
+    "indigo": {
+        "message": "Indigo"
+    },
+    "items": {
+        "message": "Items"
+    },
+    "language": {
+        "message": "Language"
+    },
+    "languages": {
+        "message": "Languages"
+    },
+    "legacyYoutube": {
+        "message": "Legacy YouTube"
+    },
+    "library": {
+        "message": "Library"
+    },
+    "light": {
+        "message": "Light"
+    },
+    "lightBlue": {
+        "message": "Light blue"
+    },
+    "lightGreen": {
+        "message": "Light green"
+    },
+    "like": {
+        "message": "Like"
+    },
+    "likeAndDislike": {
+        "message": "Like and Dislike "
+    },
+    "liked": {
+        "message": "Liked"
+    },
+    "lime": {
+        "message": "Lime"
+    },
+    "limitPageWidth": {
+        "message": "Limit page width"
+    },
+    "list": {
+        "message": "List"
+    },
+    "liveChat": {
+        "message": "Live chat"
+    },
+    "liveChatType": {
+        "message": "Live chat type"
+    },
+    "location": {
+        "message": "Location"
+    },
+    "loop": {
+        "message": "Loop"
+    },
+    "loudnessNormalization": {
+        "message": "Loudness normalization"
+    },
+    "low": {
+        "message": "Low"
+    },
+    "markWatchedVideos": {
+        "message": "Mark watched videos"
+    },
+    "medium": {
+        "message": "Medium"
+    },
+    "mixer": {
+        "message": "Mixer"
+    },
+    "more": {
+        "message": "More"
+    },
+    "moveSidebarLeft": {
+        "message": "Move sidebar left"
+    },
+    "moveThumbnailsRight": {
+        "message": "Move thumbnails right"
+    },
+    "myColors": {
+        "message": "My colors"
+    },
+    "name": {
+        "message": "Name"
+    },
+    "nativeMiniPlayer": {
+        "message": "Native mini player"
+    },
+    "new": {
+        "message": "New"
+    },
+    "nextVideo": {
+        "message": "Next video"
+    },
+    "night": {
+        "message": "Night"
+    },
+    "noActiveFeatures": {
+        "message": "No active features"
+    },
+    "noOpenVideoTabs": {
+        "message": "No open video tabs"
+    },
+    "none": {
+        "message": "None"
+    },
+    "normal": {
+        "message": "Normal"
+    },
+    "off": {
+        "message": "Off"
+    },
+    "ok": {
+        "message": "Ok"
+    },
+    "old": {
+        "message": "Old"
+    },
+    "onAllVideos": {
+        "message": "On all videos"
+    },
+    "onSubscribedChannels": {
+        "message": "On subscribed channels"
+    },
+    "onlyActiveOnYoutube": {
+        "message": "Only active on YouTube"
+    },
+    "onlyOnePlayerInstancePlaying": {
+        "message": "Only one player instance playing"
+    },
+    "openPopupPlayer": {
+        "message": "Open video/playlist in a new window"
+    },
+    "orange": {
+        "message": "Orange"
+    },
+    "os": {
+        "message": "OS"
+    },
+    "other": {
+        "message": "Other"
+    },
+    "outline": {
+        "message": "Outline"
+    },
+    "overlay": {
+        "message": "Overlay"
+    },
+    "permissions": {
+        "message": "Permissions"
+    },
+    "pictureInPicture": {
+        "message": "Picture-in-Picture"
+    },
+    "pink": {
+        "message": "Pink"
+    },
+    "plain": {
+        "message": "Plain"
+    },
+    "platform": {
+        "message": "Platform"
+    },
+    "playAllButton": {
+        "message": "\"Play all\" button"
+    },
+    "playPause": {
+        "message": "Play / Pause"
+    },
+    "playbackSpeed": {
+        "message": "Playback speed"
+    },
+    "player": {
+        "message": "Player"
+    },
+    "playerColor": {
+        "message": "Player color"
+    },
+    "playerSize": {
+        "message": "Player size"
+    },
+    "playlist": {
+        "message": "Playlist"
+    },
+    "playlists": {
+        "message": "Playlists"
+    },
+    "popupPlayer": {
+        "message": "Popup player"
+    },
+    "popupWindowButtons": {
+        "message": "Add popup Window buttons"
+    },
+    "position": {
+        "message": "Position"
+    },
+    "pressAnyKeyOrScroll": {
+        "message": "Press any key or use mouse wheel."
+    },
+    "pressAnyKeyOrUseMouseWheel": {
+        "message": "Press any key or use mouse wheel"
+    },
+    "previousVideo": {
+        "message": "Previous video"
+    },
+    "primaryColor": {
+        "message": "Primary color"
+    },
+    "purple": {
+        "message": "Purple"
+    },
+    "quality": {
+        "message": "Quality"
+    },
+    "raised": {
+        "message": "Raised"
+    },
+    "ram": {
+        "message": "RAM"
+    },
+    "rateMe": {
+        "message": "Rate me"
+    },
+    "rateUs": {
+        "message": "Rate us"
+    },
+    "red": {
+        "message": "Red"
+    },
+    "redDislikeButton": {
+        "message": "Show dislike button in red"
+    },
+    "relatedVideos": {
+        "message": "Related videos"
+    },
+    "remote": {
+        "message": "Play on TV"
+    },
+    "removeRelatedSearchResults": {
+        "message": "Remove related search results"
+    },
+    "repeat": {
+        "message": "Repeat"
+    },
+    "report": {
+        "message": "Report"
+    },
+    "reset": {
+        "message": "Reset"
+    },
+    "resetAllSettings": {
+        "message": "Reset all settings"
+    },
+    "resetAllShortcuts": {
+        "message": "Reset all shortcuts"
+    },
+    "reverse": {
+        "message": "Reverse"
+    },
+    "rotate": {
+        "message": "Rotate"
+    },
+    "save": {
+        "message": "Save"
+    },
+    "saveAs": {
+        "message": "Save as"
+    },
+    "schedule": {
+        "message": "Schedule"
+    },
+    "screen": {
+        "message": "Screen"
+    },
+    "screenshot": {
+        "message": "Screenshot"
+    },
+    "scrollBar": {
+        "message": "Scroll Bar"
+    },
+    "sd": {
+        "message": "SD"
+    },
+    "search": {
+        "message": "Search"
+    },
+    "searchBarOnly": {
+        "message": "Search bar only"
+    },
+    "seekBackward10Seconds": {
+        "message": "Seek backward 10 seconds"
+    },
+    "seekForward10Seconds": {
+        "message": "Seek forward 10 seconds"
+    },
+    "seekNextChapter": {
+        "message": "Seek Next Chapter"
+    },
+    "seekPreviousChapter": {
+        "message": "Seek Previous Chapter"
+    },
+    "settings": {
+        "message": "Settings"
+    },
+    "settingsSuccessfullyImported": {
+        "message": "Settings successfully imported"
+    },
+    "share": {
+        "message": "Share"
+    },
+    "shortcuts": {
+        "message": "Shortcuts"
+    },
+    "showCardsOnMouseHover": {
+        "message": "Show cards on mouse hover"
+    },
+    "showChannelVideosCount": {
+        "message": "Show channel videos count"
+    },
+    "showLess": {
+        "message": "Show less"
+    },
+    "showMore": {
+        "message": "Show more"
+    },
+    "showRemainingDuration": {
+        "message": "Show video remaining duration"
+    },
+    "shuffle": {
+        "message": "Shuffle"
+    },
+    "sidebar": {
+        "message": "Sidebar"
+    },
+    "spacebar": {
+        "message": "Spacebar"
+    },
+    "squaredUserImages": {
+        "message": "Squared user images"
+    },
+    "static": {
+        "message": "Static"
+    },
+    "statsForNerds": {
+        "message": "Show Stats for Nerds"
+    },
+    "step": {
+        "message": "Step"
+    },
+    "stop": {
+        "message": "Stop"
+    },
+    "style": {
+        "message": "Style"
+    },
+    "styles": {
+        "message": "Styles"
+    },
+    "subscribe": {
+        "message": "Subscribe"
+    },
+    "subscriptions": {
+        "message": "Subscriptions"
+    },
+    "subtitles": {
+        "message": "Subtitles"
+    },
+    "sunset": {
+        "message": "Sunset"
+    },
+    "sunsetToSunrise": {
+        "message": "Sunset to sunrise"
+    },
+    "systemPeferenceDark": {
+        "message": "System preference: dark"
+    },
+    "systemPeferenceLight": {
+        "message": "System preference: light"
+    },
+    "teal": {
+        "message": "Teal"
+    },
+    "textColor": {
+        "message": "Text color"
+    },
+    "thanks": {
+        "message": "Thanks"
+    },
+    "themes": {
+        "message": "Themes"
+    },
+    "thisWillRemoveAllCookies": {
+        "message": "This will remove all cookies."
+    },
+    "thisWillRemoveAllWatchedVideos": {
+        "message": "This will remove all watched videos."
+    },
+    "thisWillRemoveAllYouTubeCookies": {
+        "message": "This will remove all YouTube cookies"
+    },
+    "thisWillResetAllSettings": {
+        "message": "This will reset all settings."
+    },
+    "thisWillResetAllShortcuts": {
+        "message": "This will reset all shortcuts"
+    },
+    "thumbnails": {
+        "message": "Thumbnails"
+    },
+    "thumbnailsQuality": {
+        "message": "Thumbnails Quality"
+    },
+    "timeFrom": {
+        "message": "Time from"
+    },
+    "timeTo": {
+        "message": "Time to"
+    },
+    "todayAt": {
+        "message": "Today at"
+    },
+    "toggleAutoplay": {
+        "message": "Toggle autoplay"
+    },
+    "toggleCards": {
+        "message": "Toggle cards"
+    },
+    "toggleControls": {
+        "message": "Toggle player controls"
+    },
+    "topChat": {
+        "message": "Top chat"
+    },
+    "trackWatchedVideos": {
+        "message": "Track watched videos"
+    },
+    "trailerAutoplay": {
+        "message": "Trailer autoplay"
+    },
+    "translations": {
+        "message": "Translations"
+    },
+    "transparentBackground": {
+        "message": "Transparent background"
+    },
+    "trending": {
+        "message": "Trending"
+    },
+    "tryToReloadThePage": {
+        "message": "Try to reload the page"
+    },
+    "type": {
+        "message": "Type"
+    },
+    "upNextAutoplay": {
+        "message": "Up next autoplay"
+    },
+    "use24HourFormat": {
+        "message": "Use 24-hour format"
+    },
+    "version": {
+        "message": "Version"
+    },
+    "video": {
+        "message": "Video"
+    },
+    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
+        "message": "The video description will be expanded to get the name of the category"
+    },
+    "videoFormats": {
+        "message": "Video formats"
+    },
+    "videos": {
+        "message": "Videos"
+    },
+    "viewMode": {
+        "message": "View Mode"
+    },
+    "volume": {
+        "message": "Volume"
+    },
+    "watchLater": {
+        "message": "Watch later"
+    },
+    "watchTime": {
+        "message": "Watch time"
+    },
+    "whenPaused": {
+        "message": "When paused"
+    },
+    "whenTabIsChanged": {
+        "message": "When tab is changed"
+    },
+    "white": {
+        "message": "White"
+    },
+    "windowColor": {
+        "message": "Window color"
+    },
+    "windowOpacity": {
+        "message": "Window opacity"
+    },
+    "yellow": {
+        "message": "Yellow"
+    },
+    "youtubeHeaderLeft": {
+        "message": "YouTube Header (left)"
+    },
+    "youtubeHeaderRight": {
+        "message": "YouTube Header (right)"
+    },
+    "youtubeHomePage": {
+        "message": "YouTube home page"
+    },
+    "youtubeLanguage": {
+        "message": "YouTube language"
+    },
+    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
+        "message": "YouTube limits video quality to 1080p for h.264 codec"
+    }
+}

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -1,0 +1,1070 @@
+{
+    "ARROWDOWN": {
+        "message": "⇩"
+    },
+    "ARROWLEFT": {
+        "message": "⇦"
+    },
+    "ARROWRIGHT": {
+        "message": "⇨"
+    },
+    "ARROWUP": {
+        "message": "⇧"
+    },
+    "about": {
+        "message": "About"
+    },
+    "accept": {
+        "message": "Accept"
+    },
+    "activate": {
+        "message": "Activate"
+    },
+    "activateCaptions": {
+        "message": "Activate captions"
+    },
+    "activateFullscreen": {
+        "message": "Activate fullscreen"
+    },
+    "activated": {
+        "message": "Activated"
+    },
+    "activatedFeatures": {
+        "message": "Activated features"
+    },
+    "activeFeatures": {
+        "message": "Active features"
+    },
+    "addScrollToTop": {
+        "message": "Add «Scroll to top»"
+    },
+    "ads": {
+        "message": "Ads"
+    },
+    "all": {
+        "message": "All"
+    },
+    "allow": {
+        "message": "Allow"
+    },
+    "allow60fps": {
+        "message": "Allow 60fps"
+    },
+    "always": {
+        "message": "Always"
+    },
+    "alwaysActive": {
+        "message": "Always active"
+    },
+    "alwaysShowProgressBar": {
+        "message": "Always show progress bar"
+    },
+    "amber": {
+        "message": "Amber"
+    },
+    "analyzer": {
+        "message": "Analyzer"
+    },
+    "appearance": {
+        "message": "Appearance"
+    },
+    "areYouSureYouWantToExportTheData": {
+        "message": "Are you sure you want to export the data?"
+    },
+    "areYouSureYouWantToImportTheData": {
+        "message": "Are you sure you want to import this data?"
+    },
+    "audio": {
+        "message": "Audio"
+    },
+    "audioFormats": {
+        "message": "Audio formats"
+    },
+    "auto": {
+        "message": "Auto"
+    },
+    "autoFullscreen": {
+        "message": "Auto-fullscreen"
+    },
+    "autopauseWhenSwitchingTabs": {
+        "message": "Autopause when switching tabs"
+    },
+    "autoplay": {
+        "message": "Autoplay"
+    },
+    "avoidAv1": {
+        "message": "Avoid AV1"
+    },
+    "avoidAv1Vp8Vp9": {
+        "message": "Avoid AV1, VP8, VP9"
+    },
+    "avoidAv1Vp9": {
+        "message": "Avoid AV1, VP9"
+    },
+    "avoidCpuRenderingWhenPossible": {
+        "message": "Avoid CPU rendering when possible"
+    },
+    "backgroundColor": {
+        "message": "Background color"
+    },
+    "backgroundOpacity": {
+        "message": "Background opacity"
+    },
+    "backupAndReset": {
+        "message": "Backup & reset"
+    },
+    "baseOnSystemColorScheme": {
+        "message": "Base on system color scheme"
+    },
+    "belowPlayer": {
+        "message": "Below player"
+    },
+    "black": {
+        "message": "Black"
+    },
+    "blacklist": {
+        "message": "Blacklist"
+    },
+    "blockAll": {
+        "message": "Block all"
+    },
+    "blockAv1": {
+        "message": "Block AV1"
+    },
+    "blockH264": {
+        "message": "Block H.264"
+    },
+    "blockMusic": {
+        "message": "Block music"
+    },
+    "blockVp8": {
+        "message": "Block VP8"
+    },
+    "blockVp9": {
+        "message": "Block VP9"
+    },
+    "blue": {
+        "message": "Blue"
+    },
+    "blueGray": {
+        "message": "Blue gray"
+    },
+    "bluelight": {
+        "message": "Bluelight"
+    },
+    "brown": {
+        "message": "Brown"
+    },
+    "browser": {
+        "message": "Browser"
+    },
+    "browserVersion": {
+        "message": "Browser version"
+    },
+    "bubbles": {
+        "message": "Bubbles"
+    },
+    "bug": {
+        "message": "Bug"
+    },
+    "buttons": {
+        "message": "Buttons"
+    },
+    "cancel": {
+        "message": "Cancel"
+    },
+    "categories": {
+        "message": "Categories"
+    },
+    "channel": {
+        "message": "Channel"
+    },
+    "channels": {
+        "message": "Channels"
+    },
+    "characterEdgeStyle": {
+        "message": "Character edge style"
+    },
+    "clip": {
+        "message": "Clip"
+    },
+    "clipboard": {
+        "message": "Clipboard"
+    },
+    "codecH264": {
+        "message": "Codec h.264"
+    },
+    "codecs": {
+        "message": "Codecs"
+    },
+    "collapseOfSubscriptionSections": {
+        "message": "Collapse of subscription sections"
+    },
+    "collapsed": {
+        "message": "Collapsed"
+    },
+    "comments": {
+        "message": "Comments"
+    },
+    "confirmationBeforeClosing": {
+        "message": "Confirmation before closing"
+    },
+    "cookies": {
+        "message": "Cookies"
+    },
+    "cores": {
+        "message": "Cores"
+    },
+    "cropChapterTitles": {
+        "message": "Crop chapter titles"
+    },
+    "custom": {
+        "message": "Custom"
+    },
+    "customCss": {
+        "message": "Custom CSS"
+    },
+    "customJs": {
+        "message": "Custom JS"
+    },
+    "customMiniPlayer": {
+        "message": "Custom Mini-Player"
+    },
+    "cyan": {
+        "message": "Cyan"
+    },
+    "dark": {
+        "message": "Dark"
+    },
+    "darkTheme": {
+        "message": "Dark theme"
+    },
+    "dateAndTime": {
+        "message": "Date & time"
+    },
+    "dawn": {
+        "message": "Dawn"
+    },
+    "decreasePlaybackSpeed": {
+        "message": "Decrease playback speed"
+    },
+    "decreaseVolume": {
+        "message": "Decrease volume"
+    },
+    "deepOrange": {
+        "message": "Deep orange"
+    },
+    "deepPurple": {
+        "message": "Deep purple"
+    },
+    "default": {
+        "message": "Default"
+    },
+    "defaultChannelTab": {
+        "message": "Default channel tab"
+    },
+    "defaultContentCountry": {
+        "message": "Default content country"
+    },
+    "deleteWatchedVideos": {
+        "message": "Delete watched videos"
+    },
+    "deleteYoutubeCookies": {
+        "message": "Delete YouTube cookies"
+    },
+    "depressed": {
+        "message": "Depressed"
+    },
+    "description": {
+        "message": "Description"
+    },
+    "description_ext": {
+        "message": "Make YouTube tidy+smart! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+    },
+    "desert": {
+        "message": "Desert"
+    },
+    "details": {
+        "message": "Details"
+    },
+    "developerOptions": {
+        "message": "Developer options"
+    },
+    "device": {
+        "message": "Device"
+    },
+    "dim": {
+        "message": "Dim"
+    },
+    "disabled": {
+        "message": "Disabled"
+    },
+    "dislike": {
+        "message": "Dislike"
+    },
+    "doNotChange": {
+        "message": "Don't change"
+    },
+    "donate": {
+        "message": "Donate"
+    },
+    "download": {
+        "message": "Download"
+    },
+    "draggable": {
+        "message": "Draggable"
+    },
+    "dropShadow": {
+        "message": "Drop shadow"
+    },
+    "durationWithSpeed": {
+        "message": "Show time remaining with reference to playback speed"
+    },
+    "email": {
+        "message": "Email"
+    },
+    "empty": {
+        "message": "Empty"
+    },
+    "enabled": {
+        "message": "Enabled"
+    },
+    "enabledForced": {
+        "message": "Enabled (forced)"
+    },
+    "expanded": {
+        "message": "Expanded"
+    },
+    "exportSettings": {
+        "message": "Export settings"
+    },
+    "extension": {
+        "message": "Extension"
+    },
+    "file": {
+        "message": "File"
+    },
+    "filters": {
+        "message": "Filters"
+    },
+    "fitToWindow": {
+        "message": "Fit to window"
+    },
+    "flash": {
+        "message": "Flash"
+    },
+    "font": {
+        "message": "Font"
+    },
+    "fontColor": {
+        "message": "Font color"
+    },
+    "fontFamily": {
+        "message": "Font family"
+    },
+    "fontOpacity": {
+        "message": "Font opacity"
+    },
+    "fontSize": {
+        "message": "Font size"
+    },
+    "footer": {
+        "message": "Footer"
+    },
+    "forceSDR": {
+        "message": "Force SDR"
+    },
+    "forcedPlayVideoFromTheBeginning": {
+        "message": "Force video to play from the beginning"
+    },
+    "forcedPlaybackSpeed": {
+        "message": "Forced playback speed"
+    },
+    "forcedTheaterMode": {
+        "message": "Forced theater mode"
+    },
+    "forcedVolume": {
+        "message": "Forced volume"
+    },
+    "foundABug": {
+        "message": "Found a bug?"
+    },
+    "fullWindow": {
+        "message": "Full window"
+    },
+    "general": {
+        "message": "General"
+    },
+    "geoPreference": {
+        "message": "Geo Preference"
+    },
+    "github": {
+        "message": "GitHub"
+    },
+    "goToSearchBox": {
+        "message": "Go to search box"
+    },
+    "googleApiKey": {
+        "message": "Google API key"
+    },
+    "gpu": {
+        "message": "GPU"
+    },
+    "green": {
+        "message": "Green"
+    },
+    "hd": {
+        "message": "HD"
+    },
+    "hdThumbnail": {
+        "message": "HD thumbnail"
+    },
+    "header": {
+        "message": "Header"
+    },
+    "hidden": {
+        "message": "Hidden"
+    },
+    "hiddenOnVideoPage": {
+        "message": "Hidden on video page"
+    },
+    "hideAnimatedThumbnails": {
+        "message": "Hide animated thumbnails"
+    },
+    "hideAnnotations": {
+        "message": "Hide annotations"
+    },
+    "hideButtonLabel": {
+        "message": "Hide Button Label"
+    },
+    "hideCards": {
+        "message": "Hide cards"
+    },
+    "hideCountryCode": {
+        "message": "Hide country code"
+    },
+    "hideDate": {
+        "message": "Hide date"
+    },
+    "hideDetailButton": {
+        "message": "Hide Detail Button"
+    },
+    "hideDetails": {
+        "message": "Hide details"
+    },
+    "hideEndscreen": {
+        "message": "Hide endscreen"
+    },
+    "hideFeaturedContent": {
+        "message": "Hide featured content"
+    },
+    "hideFooter": {
+        "message": "Hide footer"
+    },
+    "hideGradientBottom": {
+        "message": "Hide shadow around player-bar"
+    },
+    "hidePlayerControlsBar": {
+        "message": "Hide player controls bar"
+    },
+    "hidePlayerControlsBarButtons": {
+        "message": "Hide player controls     buttons"
+    },
+    "hidePlayerControlsBarOptions": {
+        "message": "Hide player controls options"
+    },
+    "hidePlaylist": {
+        "message": "Hide playlist"
+    },
+    "hideRightButtons": {
+        "message": "Hide right buttons"
+    },
+    "hideScrollForDetails": {
+        "message": "Hide «Scroll for details»"
+    },
+    "hideSkipOverlay": {
+        "message": "Hide 5 second skip animation"
+    },
+    "hideThumbnailOverlay": {
+        "message": "Hide buttons on thumbnails"
+    },
+    "hideThumbnails": {
+        "message": "Hide thumbnails"
+    },
+    "hideViewsCount": {
+        "message": "Hide views count"
+    },
+    "hideVoiceSearchButton": {
+        "message": "Hide voice search button"
+    },
+    "high": {
+        "message": "High"
+    },
+    "history": {
+        "message": "History"
+    },
+    "home": {
+        "message": "Home"
+    },
+    "hover": {
+        "message": "Hover"
+    },
+    "hoverOnVideoPage": {
+        "message": "Hover on video page"
+    },
+    "howLongAgoTheVideoWasUploaded": {
+        "message": "How long ago the video was uploaded"
+    },
+    "icons": {
+        "message": "Icons"
+    },
+    "iconsOnly": {
+        "message": "Icons only"
+    },
+    "importSettings": {
+        "message": "Import settings"
+    },
+    "improveLogo": {
+        "message": "Improve logo"
+    },
+    "improvedtubeButtons": {
+        "message": "ImprovedTube buttons"
+    },
+    "improvedtubeIconOnYoutube": {
+        "message": "ImprovedTube icon on YouTube"
+    },
+    "improvedtubeLanguage": {
+        "message": "ImprovedTube language"
+    },
+    "improvedtubeVersion": {
+        "message": "ImprovedTube version"
+    },
+    "increasePlaybackSpeed": {
+        "message": "Increase playback speed"
+    },
+    "increaseVolume": {
+        "message": "Increase volume"
+    },
+    "indigo": {
+        "message": "Indigo"
+    },
+    "items": {
+        "message": "Items"
+    },
+    "language": {
+        "message": "Language"
+    },
+    "languages": {
+        "message": "Languages"
+    },
+    "legacyYoutube": {
+        "message": "Legacy YouTube"
+    },
+    "library": {
+        "message": "Library"
+    },
+    "light": {
+        "message": "Light"
+    },
+    "lightBlue": {
+        "message": "Light blue"
+    },
+    "lightGreen": {
+        "message": "Light green"
+    },
+    "like": {
+        "message": "Like"
+    },
+    "likeAndDislike": {
+        "message": "Like and Dislike "
+    },
+    "liked": {
+        "message": "Liked"
+    },
+    "lime": {
+        "message": "Lime"
+    },
+    "limitPageWidth": {
+        "message": "Limit page width"
+    },
+    "list": {
+        "message": "List"
+    },
+    "liveChat": {
+        "message": "Live chat"
+    },
+    "liveChatType": {
+        "message": "Live chat type"
+    },
+    "location": {
+        "message": "Location"
+    },
+    "loop": {
+        "message": "Loop"
+    },
+    "loudnessNormalization": {
+        "message": "Loudness normalization"
+    },
+    "low": {
+        "message": "Low"
+    },
+    "markWatchedVideos": {
+        "message": "Mark watched videos"
+    },
+    "medium": {
+        "message": "Medium"
+    },
+    "mixer": {
+        "message": "Mixer"
+    },
+    "more": {
+        "message": "More"
+    },
+    "moveSidebarLeft": {
+        "message": "Move sidebar left"
+    },
+    "moveThumbnailsRight": {
+        "message": "Move thumbnails right"
+    },
+    "myColors": {
+        "message": "My colors"
+    },
+    "name": {
+        "message": "Name"
+    },
+    "nativeMiniPlayer": {
+        "message": "Native mini player"
+    },
+    "new": {
+        "message": "New"
+    },
+    "nextVideo": {
+        "message": "Next video"
+    },
+    "night": {
+        "message": "Night"
+    },
+    "noActiveFeatures": {
+        "message": "No active features"
+    },
+    "noOpenVideoTabs": {
+        "message": "No open video tabs"
+    },
+    "none": {
+        "message": "None"
+    },
+    "normal": {
+        "message": "Normal"
+    },
+    "off": {
+        "message": "Off"
+    },
+    "ok": {
+        "message": "Ok"
+    },
+    "old": {
+        "message": "Old"
+    },
+    "onAllVideos": {
+        "message": "On all videos"
+    },
+    "onSubscribedChannels": {
+        "message": "On subscribed channels"
+    },
+    "onlyActiveOnYoutube": {
+        "message": "Only active on YouTube"
+    },
+    "onlyOnePlayerInstancePlaying": {
+        "message": "Only one player instance playing"
+    },
+    "openPopupPlayer": {
+        "message": "Open video/playlist in a new window"
+    },
+    "orange": {
+        "message": "Orange"
+    },
+    "os": {
+        "message": "OS"
+    },
+    "other": {
+        "message": "Other"
+    },
+    "outline": {
+        "message": "Outline"
+    },
+    "overlay": {
+        "message": "Overlay"
+    },
+    "permissions": {
+        "message": "Permissions"
+    },
+    "pictureInPicture": {
+        "message": "Picture-in-Picture"
+    },
+    "pink": {
+        "message": "Pink"
+    },
+    "plain": {
+        "message": "Plain"
+    },
+    "platform": {
+        "message": "Platform"
+    },
+    "playAllButton": {
+        "message": "\"Play all\" button"
+    },
+    "playPause": {
+        "message": "Play / Pause"
+    },
+    "playbackSpeed": {
+        "message": "Playback speed"
+    },
+    "player": {
+        "message": "Player"
+    },
+    "playerColor": {
+        "message": "Player color"
+    },
+    "playerSize": {
+        "message": "Player size"
+    },
+    "playlist": {
+        "message": "Playlist"
+    },
+    "playlists": {
+        "message": "Playlists"
+    },
+    "popupPlayer": {
+        "message": "Popup player"
+    },
+    "popupWindowButtons": {
+        "message": "Add popup Window buttons"
+    },
+    "position": {
+        "message": "Position"
+    },
+    "pressAnyKeyOrScroll": {
+        "message": "Press any key or use mouse wheel."
+    },
+    "pressAnyKeyOrUseMouseWheel": {
+        "message": "Press any key or use mouse wheel"
+    },
+    "previousVideo": {
+        "message": "Previous video"
+    },
+    "primaryColor": {
+        "message": "Primary color"
+    },
+    "purple": {
+        "message": "Purple"
+    },
+    "quality": {
+        "message": "Quality"
+    },
+    "raised": {
+        "message": "Raised"
+    },
+    "ram": {
+        "message": "RAM"
+    },
+    "rateMe": {
+        "message": "Rate me"
+    },
+    "rateUs": {
+        "message": "Rate us"
+    },
+    "red": {
+        "message": "Red"
+    },
+    "redDislikeButton": {
+        "message": "Show dislike button in red"
+    },
+    "relatedVideos": {
+        "message": "Related videos"
+    },
+    "remote": {
+        "message": "Play on TV"
+    },
+    "removeRelatedSearchResults": {
+        "message": "Remove related search results"
+    },
+    "repeat": {
+        "message": "Repeat"
+    },
+    "report": {
+        "message": "Report"
+    },
+    "reset": {
+        "message": "Reset"
+    },
+    "resetAllSettings": {
+        "message": "Reset all settings"
+    },
+    "resetAllShortcuts": {
+        "message": "Reset all shortcuts"
+    },
+    "reverse": {
+        "message": "Reverse"
+    },
+    "rotate": {
+        "message": "Rotate"
+    },
+    "save": {
+        "message": "Save"
+    },
+    "saveAs": {
+        "message": "Save as"
+    },
+    "schedule": {
+        "message": "Schedule"
+    },
+    "screen": {
+        "message": "Screen"
+    },
+    "screenshot": {
+        "message": "Screenshot"
+    },
+    "scrollBar": {
+        "message": "Scroll Bar"
+    },
+    "sd": {
+        "message": "SD"
+    },
+    "search": {
+        "message": "Search"
+    },
+    "searchBarOnly": {
+        "message": "Search bar only"
+    },
+    "seekBackward10Seconds": {
+        "message": "Seek backward 10 seconds"
+    },
+    "seekForward10Seconds": {
+        "message": "Seek forward 10 seconds"
+    },
+    "seekNextChapter": {
+        "message": "Seek Next Chapter"
+    },
+    "seekPreviousChapter": {
+        "message": "Seek Previous Chapter"
+    },
+    "settings": {
+        "message": "Settings"
+    },
+    "settingsSuccessfullyImported": {
+        "message": "Settings successfully imported"
+    },
+    "share": {
+        "message": "Share"
+    },
+    "shortcuts": {
+        "message": "Shortcuts"
+    },
+    "showCardsOnMouseHover": {
+        "message": "Show cards on mouse hover"
+    },
+    "showChannelVideosCount": {
+        "message": "Show channel videos count"
+    },
+    "showLess": {
+        "message": "Show less"
+    },
+    "showMore": {
+        "message": "Show more"
+    },
+    "showRemainingDuration": {
+        "message": "Show video remaining duration"
+    },
+    "shuffle": {
+        "message": "Shuffle"
+    },
+    "sidebar": {
+        "message": "Sidebar"
+    },
+    "spacebar": {
+        "message": "Spacebar"
+    },
+    "squaredUserImages": {
+        "message": "Squared user images"
+    },
+    "static": {
+        "message": "Static"
+    },
+    "statsForNerds": {
+        "message": "Show Stats for Nerds"
+    },
+    "step": {
+        "message": "Step"
+    },
+    "stop": {
+        "message": "Stop"
+    },
+    "style": {
+        "message": "Style"
+    },
+    "styles": {
+        "message": "Styles"
+    },
+    "subscribe": {
+        "message": "Subscribe"
+    },
+    "subscriptions": {
+        "message": "Subscriptions"
+    },
+    "subtitles": {
+        "message": "Subtitles"
+    },
+    "sunset": {
+        "message": "Sunset"
+    },
+    "sunsetToSunrise": {
+        "message": "Sunset to sunrise"
+    },
+    "systemPeferenceDark": {
+        "message": "System preference: dark"
+    },
+    "systemPeferenceLight": {
+        "message": "System preference: light"
+    },
+    "teal": {
+        "message": "Teal"
+    },
+    "textColor": {
+        "message": "Text color"
+    },
+    "thanks": {
+        "message": "Thanks"
+    },
+    "themes": {
+        "message": "Themes"
+    },
+    "thisWillRemoveAllCookies": {
+        "message": "This will remove all cookies."
+    },
+    "thisWillRemoveAllWatchedVideos": {
+        "message": "This will remove all watched videos."
+    },
+    "thisWillRemoveAllYouTubeCookies": {
+        "message": "This will remove all YouTube cookies"
+    },
+    "thisWillResetAllSettings": {
+        "message": "This will reset all settings."
+    },
+    "thisWillResetAllShortcuts": {
+        "message": "This will reset all shortcuts"
+    },
+    "thumbnails": {
+        "message": "Thumbnails"
+    },
+    "thumbnailsQuality": {
+        "message": "Thumbnails Quality"
+    },
+    "timeFrom": {
+        "message": "Time from"
+    },
+    "timeTo": {
+        "message": "Time to"
+    },
+    "todayAt": {
+        "message": "Today at"
+    },
+    "toggleAutoplay": {
+        "message": "Toggle autoplay"
+    },
+    "toggleCards": {
+        "message": "Toggle cards"
+    },
+    "toggleControls": {
+        "message": "Toggle player controls"
+    },
+    "topChat": {
+        "message": "Top chat"
+    },
+    "trackWatchedVideos": {
+        "message": "Track watched videos"
+    },
+    "trailerAutoplay": {
+        "message": "Trailer autoplay"
+    },
+    "translations": {
+        "message": "Translations"
+    },
+    "transparentBackground": {
+        "message": "Transparent background"
+    },
+    "trending": {
+        "message": "Trending"
+    },
+    "tryToReloadThePage": {
+        "message": "Try to reload the page"
+    },
+    "type": {
+        "message": "Type"
+    },
+    "upNextAutoplay": {
+        "message": "Up next autoplay"
+    },
+    "use24HourFormat": {
+        "message": "Use 24-hour format"
+    },
+    "version": {
+        "message": "Version"
+    },
+    "video": {
+        "message": "Video"
+    },
+    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
+        "message": "The video description will be expanded to get the name of the category"
+    },
+    "videoFormats": {
+        "message": "Video formats"
+    },
+    "videos": {
+        "message": "Videos"
+    },
+    "viewMode": {
+        "message": "View Mode"
+    },
+    "volume": {
+        "message": "Volume"
+    },
+    "watchLater": {
+        "message": "Watch later"
+    },
+    "watchTime": {
+        "message": "Watch time"
+    },
+    "whenPaused": {
+        "message": "When paused"
+    },
+    "whenTabIsChanged": {
+        "message": "When tab is changed"
+    },
+    "white": {
+        "message": "White"
+    },
+    "windowColor": {
+        "message": "Window color"
+    },
+    "windowOpacity": {
+        "message": "Window opacity"
+    },
+    "yellow": {
+        "message": "Yellow"
+    },
+    "youtubeHeaderLeft": {
+        "message": "YouTube Header (left)"
+    },
+    "youtubeHeaderRight": {
+        "message": "YouTube Header (right)"
+    },
+    "youtubeHomePage": {
+        "message": "YouTube home page"
+    },
+    "youtubeLanguage": {
+        "message": "YouTube language"
+    },
+    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
+        "message": "YouTube limits video quality to 1080p for h.264 codec"
+    }
+}

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -12,175 +12,175 @@
         "message": "⇧"
     },
     "about": {
-        "message": "About"
+        "message": "Acerca de"
     },
     "accept": {
-        "message": "Accept"
+        "message": "Aceptar"
     },
     "activate": {
-        "message": "Activate"
+        "message": "Activar"
     },
     "activateCaptions": {
-        "message": "Activate captions"
+        "message": "Activar subtítulos"
     },
     "activateFullscreen": {
-        "message": "Activate fullscreen"
+        "message": "Activar pantalla completa"
     },
     "activated": {
-        "message": "Activated"
+        "message": "Activado"
     },
     "activatedFeatures": {
-        "message": "Activated features"
+        "message": "Características activadas"
     },
     "activeFeatures": {
-        "message": "Active features"
+        "message": "Activar características"
     },
     "addScrollToTop": {
-        "message": "Add «Scroll to top»"
+        "message": "Añadir «Volver arriba»"
     },
     "ads": {
         "message": "Ads"
     },
     "all": {
-        "message": "All"
+        "message": "Todo"
     },
     "allow": {
-        "message": "Allow"
+        "message": "Permitir"
     },
     "allow60fps": {
-        "message": "Allow 60fps"
+        "message": "Permitir 60fps"
     },
     "always": {
         "message": "Always"
     },
     "alwaysActive": {
-        "message": "Always active"
+        "message": "Siempre activo"
     },
     "alwaysShowProgressBar": {
-        "message": "Always show progress bar"
+        "message": "Siempre mostrar barra de progreso"
     },
     "amber": {
-        "message": "Amber"
+        "message": "Ámbar"
     },
     "analyzer": {
-        "message": "Analyzer"
+        "message": "Analizador"
     },
     "appearance": {
-        "message": "Appearance"
+        "message": "Apariencia"
     },
     "areYouSureYouWantToExportTheData": {
-        "message": "Are you sure you want to export the data?"
+        "message": "¿Estas seguro que deseas exportar la informacion?"
     },
     "areYouSureYouWantToImportTheData": {
-        "message": "Are you sure you want to import this data?"
+        "message": "¿Estas seguro que deseas importar la informacion?"
     },
     "audio": {
         "message": "Audio"
     },
     "audioFormats": {
-        "message": "Audio formats"
+        "message": "Formatos de audio"
     },
     "auto": {
-        "message": "Auto"
+        "message": "Automático"
     },
     "autoFullscreen": {
-        "message": "Auto-fullscreen"
+        "message": "Pantalla completa automática"
     },
     "autopauseWhenSwitchingTabs": {
-        "message": "Autopause when switching tabs"
+        "message": "Pausar al cambiar de pestaña"
     },
     "autoplay": {
-        "message": "Autoplay"
+        "message": "Reproducción automática"
     },
     "avoidAv1": {
-        "message": "Avoid AV1"
+        "message": "Evitar AV1"
     },
     "avoidAv1Vp8Vp9": {
-        "message": "Avoid AV1, VP8, VP9"
+        "message": "Evitar AV1, VP8, VP9"
     },
     "avoidAv1Vp9": {
-        "message": "Avoid AV1, VP9"
+        "message": "Evitar AV1, VP9"
     },
     "avoidCpuRenderingWhenPossible": {
-        "message": "Avoid CPU rendering when possible"
+        "message": "Evitar renderizar con CPU cuando sea posible"
     },
     "backgroundColor": {
-        "message": "Background color"
+        "message": "Color de fondo"
     },
     "backgroundOpacity": {
-        "message": "Background opacity"
+        "message": "Opacidad de fondo"
     },
     "backupAndReset": {
         "message": "Backup & reset"
     },
     "baseOnSystemColorScheme": {
-        "message": "Base on system color scheme"
+        "message": "Según tema del sistema"
     },
     "belowPlayer": {
-        "message": "Below player"
+        "message": "Debajo del reproductor"
     },
     "black": {
-        "message": "Black"
+        "message": "Negro"
     },
     "blacklist": {
-        "message": "Blacklist"
+        "message": "Lista negra"
     },
     "blockAll": {
-        "message": "Block all"
+        "message": "Bloquear todo"
     },
     "blockAv1": {
-        "message": "Block AV1"
+        "message": "Bloquear AV1"
     },
     "blockH264": {
-        "message": "Block H.264"
+        "message": "Bloquear H.264"
     },
     "blockMusic": {
-        "message": "Block music"
+        "message": "Bloquear musica"
     },
     "blockVp8": {
-        "message": "Block VP8"
+        "message": "Bloquear VP8"
     },
     "blockVp9": {
-        "message": "Block VP9"
+        "message": "Bloquear VP9"
     },
     "blue": {
-        "message": "Blue"
+        "message": "Azul"
     },
     "blueGray": {
-        "message": "Blue gray"
+        "message": "Gris azulado"
     },
     "bluelight": {
-        "message": "Bluelight"
+        "message": "Luz azul"
     },
     "brown": {
-        "message": "Brown"
+        "message": "Marrón"
     },
     "browser": {
-        "message": "Browser"
+        "message": "Navegador"
     },
     "browserVersion": {
-        "message": "Browser version"
+        "message": "Version del navegador"
     },
     "bubbles": {
-        "message": "Bubbles"
+        "message": "Burbujas"
     },
     "bug": {
-        "message": "Bug"
+        "message": "Error (Bug)"
     },
     "buttons": {
-        "message": "Buttons"
+        "message": "Botones"
     },
     "cancel": {
-        "message": "Cancel"
+        "message": "Cancelar"
     },
     "categories": {
-        "message": "Categories"
+        "message": "Categorías"
     },
     "channel": {
-        "message": "Channel"
+        "message": "Canal"
     },
     "channels": {
-        "message": "Channels"
+        "message": "Canales"
     },
     "characterEdgeStyle": {
         "message": "Character edge style"
@@ -189,130 +189,130 @@
         "message": "Clip"
     },
     "clipboard": {
-        "message": "Clipboard"
+        "message": "Portapapeles"
     },
     "codecH264": {
-        "message": "Codec h.264"
+        "message": "Códec h.264"
     },
     "codecs": {
         "message": "Codecs"
     },
     "collapseOfSubscriptionSections": {
-        "message": "Collapse of subscription sections"
+        "message": "Compactar sección de suscripciones"
     },
     "collapsed": {
-        "message": "Collapsed"
+        "message": "Compacto"
     },
     "comments": {
-        "message": "Comments"
+        "message": "Comentarios"
     },
     "confirmationBeforeClosing": {
-        "message": "Confirmation before closing"
+        "message": "Confirmar antes de cerrar"
     },
     "cookies": {
         "message": "Cookies"
     },
     "cores": {
-        "message": "Cores"
+        "message": "Núcleos"
     },
     "cropChapterTitles": {
-        "message": "Crop chapter titles"
+        "message": "Recortar título de capítulos"
     },
     "custom": {
         "message": "Custom"
     },
     "customCss": {
-        "message": "Custom CSS"
+        "message": "CSS personalizado"
     },
     "customJs": {
-        "message": "Custom JS"
+        "message": "JS personalizado"
     },
     "customMiniPlayer": {
-        "message": "Custom Mini-Player"
+        "message": "Mini-Reproductor personalizado"
     },
     "cyan": {
-        "message": "Cyan"
+        "message": "Cian"
     },
     "dark": {
-        "message": "Dark"
+        "message": "Oscuro"
     },
     "darkTheme": {
-        "message": "Dark theme"
+        "message": "Tema oscuro"
     },
     "dateAndTime": {
-        "message": "Date & time"
+        "message": "Fecha y hora"
     },
     "dawn": {
-        "message": "Dawn"
+        "message": "Amanecer"
     },
     "decreasePlaybackSpeed": {
-        "message": "Decrease playback speed"
+        "message": "Disminuir velocidad de reproducción"
     },
     "decreaseVolume": {
-        "message": "Decrease volume"
+        "message": "Bajar volumen"
     },
     "deepOrange": {
-        "message": "Deep orange"
+        "message": "Naranja profundo"
     },
     "deepPurple": {
-        "message": "Deep purple"
+        "message": "Violeta profundo"
     },
     "default": {
         "message": "Default"
     },
     "defaultChannelTab": {
-        "message": "Default channel tab"
+        "message": "Pestaña del canal por defecto"
     },
     "defaultContentCountry": {
-        "message": "Default content country"
+        "message": "Contenido del pais por defecto"
     },
     "deleteWatchedVideos": {
-        "message": "Delete watched videos"
+        "message": "Eliminar videos vistos"
     },
     "deleteYoutubeCookies": {
-        "message": "Delete YouTube cookies"
+        "message": "Borrar cookies de YouTube"
     },
     "depressed": {
         "message": "Depressed"
     },
     "description": {
-        "message": "Description"
+        "message": "Descripcion"
     },
     "description_ext": {
         "message": "Make YouTube tidy+smart! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
     },
     "desert": {
-        "message": "Desert"
+        "message": "Desierto"
     },
     "details": {
-        "message": "Details"
+        "message": "Detalles"
     },
     "developerOptions": {
-        "message": "Developer options"
+        "message": "Opciones de desarrollador"
     },
     "device": {
-        "message": "Device"
+        "message": "Dispositivo"
     },
     "dim": {
-        "message": "Dim"
+        "message": "Oscuro"
     },
     "disabled": {
-        "message": "Disabled"
+        "message": "Desactivado"
     },
     "dislike": {
         "message": "Dislike"
     },
     "doNotChange": {
-        "message": "Don't change"
+        "message": "No cambiar"
     },
     "donate": {
-        "message": "Donate"
+        "message": "Donar"
     },
     "download": {
         "message": "Download"
     },
     "draggable": {
-        "message": "Draggable"
+        "message": "Arrastrable"
     },
     "dropShadow": {
         "message": "Drop shadow"
@@ -324,73 +324,73 @@
         "message": "Email"
     },
     "empty": {
-        "message": "Empty"
+        "message": "Vacío"
     },
     "enabled": {
-        "message": "Enabled"
+        "message": "Activado"
     },
     "enabledForced": {
-        "message": "Enabled (forced)"
+        "message": "Activado (forzado)"
     },
     "expanded": {
-        "message": "Expanded"
+        "message": "Expandido"
     },
     "exportSettings": {
-        "message": "Export settings"
+        "message": "Exportar configuración"
     },
     "extension": {
-        "message": "Extension"
+        "message": "Extensión"
     },
     "file": {
-        "message": "File"
+        "message": "Archivo"
     },
     "filters": {
-        "message": "Filters"
+        "message": "Filtros"
     },
     "fitToWindow": {
-        "message": "Fit to window"
+        "message": "Ajustar a la ventana"
     },
     "flash": {
         "message": "Flash"
     },
     "font": {
-        "message": "Font"
+        "message": "Fuente"
     },
     "fontColor": {
-        "message": "Font color"
+        "message": "Color de fuente"
     },
     "fontFamily": {
-        "message": "Font family"
+        "message": "Tipografia de fuente"
     },
     "fontOpacity": {
-        "message": "Font opacity"
+        "message": "Opacidad de fuente"
     },
     "fontSize": {
-        "message": "Font size"
+        "message": "Tamaño de fuente"
     },
     "footer": {
-        "message": "Footer"
+        "message": "Pie de pagina"
     },
     "forceSDR": {
-        "message": "Force SDR"
+        "message": "Forzar SDR"
     },
     "forcedPlayVideoFromTheBeginning": {
-        "message": "Force video to play from the beginning"
+        "message": "Forzar la reproduccion del video desde el inicio"
     },
     "forcedPlaybackSpeed": {
-        "message": "Forced playback speed"
+        "message": "Forzar velocidad de reproducción"
     },
     "forcedTheaterMode": {
-        "message": "Forced theater mode"
+        "message": "Forzar modo teatro"
     },
     "forcedVolume": {
-        "message": "Forced volume"
+        "message": "Forzar volumen"
     },
     "foundABug": {
-        "message": "Found a bug?"
+        "message": "¿Encontraste un error (bug)?"
     },
     "fullWindow": {
-        "message": "Full window"
+        "message": "Pantalla completa"
     },
     "general": {
         "message": "General"
@@ -402,7 +402,7 @@
         "message": "GitHub"
     },
     "goToSearchBox": {
-        "message": "Go to search box"
+        "message": "Ir a la barra de búsqueda"
     },
     "googleApiKey": {
         "message": "Google API key"
@@ -411,247 +411,247 @@
         "message": "GPU"
     },
     "green": {
-        "message": "Green"
+        "message": "Verde"
     },
     "hd": {
         "message": "HD"
     },
     "hdThumbnail": {
-        "message": "HD thumbnail"
+        "message": "Miniatura HD"
     },
     "header": {
-        "message": "Header"
+        "message": "Encabezado"
     },
     "hidden": {
-        "message": "Hidden"
+        "message": "Oculto"
     },
     "hiddenOnVideoPage": {
-        "message": "Hidden on video page"
+        "message": "Oculto en la página de video"
     },
     "hideAnimatedThumbnails": {
-        "message": "Hide animated thumbnails"
+        "message": "Ocultar miniaturas animadas"
     },
     "hideAnnotations": {
-        "message": "Hide annotations"
+        "message": "Ocultar anotaciones"
     },
     "hideButtonLabel": {
         "message": "Hide Button Label"
     },
     "hideCards": {
-        "message": "Hide cards"
+        "message": "Ocultar tarjetas"
     },
     "hideCountryCode": {
-        "message": "Hide country code"
+        "message": "Ocultar código de país"
     },
     "hideDate": {
-        "message": "Hide date"
+        "message": "Ocultar fecha"
     },
     "hideDetailButton": {
         "message": "Hide Detail Button"
     },
     "hideDetails": {
-        "message": "Hide details"
+        "message": "Ocultar detalles"
     },
     "hideEndscreen": {
-        "message": "Hide endscreen"
+        "message": "Ocultar pantalla final"
     },
     "hideFeaturedContent": {
-        "message": "Hide featured content"
+        "message": "Ocultar contenido destacado"
     },
     "hideFooter": {
-        "message": "Hide footer"
+        "message": "Ocultar pie de página"
     },
     "hideGradientBottom": {
-        "message": "Hide shadow around player-bar"
+        "message": "Ocultar parte inferior degradada"
     },
     "hidePlayerControlsBar": {
-        "message": "Hide player controls bar"
+        "message": "Ocultar la barra del reproductor"
     },
     "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls     buttons"
+        "message": "Ocultar los controles de la barra del reproductor"
     },
     "hidePlayerControlsBarOptions": {
-        "message": "Hide player controls options"
+        "message": "Ocultar opciones de control del reproductor"
     },
     "hidePlaylist": {
-        "message": "Hide playlist"
+        "message": "Ocultar playlist"
     },
     "hideRightButtons": {
-        "message": "Hide right buttons"
+        "message": "Ocultar botones de la derecha"
     },
     "hideScrollForDetails": {
-        "message": "Hide «Scroll for details»"
+        "message": "Ocultar «Desliza hacia abajo para ver más detalles»"
     },
     "hideSkipOverlay": {
-        "message": "Hide 5 second skip animation"
+        "message": "Hide Skip Overlay"
     },
     "hideThumbnailOverlay": {
-        "message": "Hide buttons on thumbnails"
+        "message": "Hide thumbnail overlay"
     },
     "hideThumbnails": {
-        "message": "Hide thumbnails"
+        "message": "Ocultar miniaturas"
     },
     "hideViewsCount": {
-        "message": "Hide views count"
+        "message": "Ocultar contador de visitas"
     },
     "hideVoiceSearchButton": {
-        "message": "Hide voice search button"
+        "message": "Ocultar boton de busqueda por voz"
     },
     "high": {
-        "message": "High"
+        "message": "Alto"
     },
     "history": {
-        "message": "History"
+        "message": "Historial"
     },
     "home": {
-        "message": "Home"
+        "message": "Inicio"
     },
     "hover": {
-        "message": "Hover"
+        "message": "Cursor sobre (hover)"
     },
     "hoverOnVideoPage": {
-        "message": "Hover on video page"
+        "message": "Cursor sobre (hover) en página de video"
     },
     "howLongAgoTheVideoWasUploaded": {
-        "message": "How long ago the video was uploaded"
+        "message": "Hace cuánto tiempo se subió el video"
     },
     "icons": {
-        "message": "Icons"
+        "message": "Iconos"
     },
     "iconsOnly": {
-        "message": "Icons only"
+        "message": "Solo iconos"
     },
     "importSettings": {
-        "message": "Import settings"
+        "message": "Importar configuración"
     },
     "improveLogo": {
-        "message": "Improve logo"
+        "message": "Mejorar logo"
     },
     "improvedtubeButtons": {
-        "message": "ImprovedTube buttons"
+        "message": "Botones ImprovedTube"
     },
     "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube icon on YouTube"
+        "message": "Icono ImprovedTube en YouTube"
     },
     "improvedtubeLanguage": {
-        "message": "ImprovedTube language"
+        "message": "Idioma de ImprovedTube"
     },
     "improvedtubeVersion": {
-        "message": "ImprovedTube version"
+        "message": "Version de ImprovedTube"
     },
     "increasePlaybackSpeed": {
-        "message": "Increase playback speed"
+        "message": "Aumentar velocidad de reproducción"
     },
     "increaseVolume": {
-        "message": "Increase volume"
+        "message": "Subir volumen"
     },
     "indigo": {
-        "message": "Indigo"
+        "message": "Índigo"
     },
     "items": {
         "message": "Items"
     },
     "language": {
-        "message": "Language"
+        "message": "Idioma"
     },
     "languages": {
-        "message": "Languages"
+        "message": "Idiomas"
     },
     "legacyYoutube": {
-        "message": "Legacy YouTube"
+        "message": " YouTube antiguo"
     },
     "library": {
-        "message": "Library"
+        "message": "Biblioteca"
     },
     "light": {
-        "message": "Light"
+        "message": "Claro"
     },
     "lightBlue": {
-        "message": "Light blue"
+        "message": "Azul claro"
     },
     "lightGreen": {
-        "message": "Light green"
+        "message": "Verde claro"
     },
     "like": {
-        "message": "Like"
+        "message": "Me gusta"
     },
     "likeAndDislike": {
         "message": "Like and Dislike "
     },
     "liked": {
-        "message": "Liked"
+        "message": "Me gusta"
     },
     "lime": {
-        "message": "Lime"
+        "message": "Lima"
     },
     "limitPageWidth": {
-        "message": "Limit page width"
+        "message": "Limitar ancho de la pagina"
     },
     "list": {
-        "message": "List"
+        "message": "Lista"
     },
     "liveChat": {
-        "message": "Live chat"
+        "message": "Chat en directo"
     },
     "liveChatType": {
-        "message": "Live chat type"
+        "message": "Tipo de chat en directo"
     },
     "location": {
-        "message": "Location"
+        "message": "Ubicación"
     },
     "loop": {
-        "message": "Loop"
+        "message": "Bucle"
     },
     "loudnessNormalization": {
-        "message": "Loudness normalization"
+        "message": "Normalización de volumen"
     },
     "low": {
-        "message": "Low"
+        "message": "Bajo"
     },
     "markWatchedVideos": {
-        "message": "Mark watched videos"
+        "message": "Marcar videos vistos"
     },
     "medium": {
-        "message": "Medium"
+        "message": "Medio"
     },
     "mixer": {
-        "message": "Mixer"
+        "message": "Mezclador"
     },
     "more": {
         "message": "More"
     },
     "moveSidebarLeft": {
-        "message": "Move sidebar left"
+        "message": "Mover barra lateral a la izquierda"
     },
     "moveThumbnailsRight": {
-        "message": "Move thumbnails right"
+        "message": "Mover miniaturas a la derecha"
     },
     "myColors": {
-        "message": "My colors"
+        "message": "Mis colores"
     },
     "name": {
-        "message": "Name"
+        "message": "Nombre"
     },
     "nativeMiniPlayer": {
-        "message": "Native mini player"
+        "message": "Mini-Reproductor nativo"
     },
     "new": {
-        "message": "New"
+        "message": "Nuevo"
     },
     "nextVideo": {
-        "message": "Next video"
+        "message": "Siguiente video"
     },
     "night": {
-        "message": "Night"
+        "message": "Noche"
     },
     "noActiveFeatures": {
-        "message": "No active features"
+        "message": "Sin características activas"
     },
     "noOpenVideoTabs": {
-        "message": "No open video tabs"
+        "message": "Sin pestañas de video abiertas"
     },
     "none": {
-        "message": "None"
+        "message": "Ninguno"
     },
     "normal": {
         "message": "Normal"
@@ -663,31 +663,31 @@
         "message": "Ok"
     },
     "old": {
-        "message": "Old"
+        "message": "Viejo"
     },
     "onAllVideos": {
-        "message": "On all videos"
+        "message": "En todos los videos"
     },
     "onSubscribedChannels": {
-        "message": "On subscribed channels"
+        "message": "En canales suscritos"
     },
     "onlyActiveOnYoutube": {
-        "message": "Only active on YouTube"
+        "message": "Solo activo en YouTube"
     },
     "onlyOnePlayerInstancePlaying": {
-        "message": "Only one player instance playing"
+        "message": "Solo una pestaña reproduciendo"
     },
     "openPopupPlayer": {
-        "message": "Open video/playlist in a new window"
+        "message": "Abrir video/lista de reproduccion en una nueva ventana"
     },
     "orange": {
-        "message": "Orange"
+        "message": "Naranja"
     },
     "os": {
         "message": "OS"
     },
     "other": {
-        "message": "Other"
+        "message": "Otro"
     },
     "outline": {
         "message": "Outline"
@@ -696,70 +696,70 @@
         "message": "Overlay"
     },
     "permissions": {
-        "message": "Permissions"
+        "message": "Permisos"
     },
     "pictureInPicture": {
-        "message": "Picture-in-Picture"
+        "message": "Imagen en imagen"
     },
     "pink": {
-        "message": "Pink"
+        "message": "Rosa"
     },
     "plain": {
-        "message": "Plain"
+        "message": "Plano"
     },
     "platform": {
-        "message": "Platform"
+        "message": "Plataforma"
     },
     "playAllButton": {
-        "message": "\"Play all\" button"
+        "message": "Boton \"Reproducir todo\""
     },
     "playPause": {
-        "message": "Play / Pause"
+        "message": "Reproducir / pausar"
     },
     "playbackSpeed": {
-        "message": "Playback speed"
+        "message": "Velocidad de reproducción"
     },
     "player": {
-        "message": "Player"
+        "message": "Reproductor"
     },
     "playerColor": {
-        "message": "Player color"
+        "message": "Color del reproductor"
     },
     "playerSize": {
-        "message": "Player size"
+        "message": "Tamaño del reproductor"
     },
     "playlist": {
-        "message": "Playlist"
+        "message": "Lista de reproducción"
     },
     "playlists": {
-        "message": "Playlists"
+        "message": "Listas de reproducción"
     },
     "popupPlayer": {
-        "message": "Popup player"
+        "message": "Reproductor emergente"
     },
     "popupWindowButtons": {
-        "message": "Add popup Window buttons"
+        "message": "popup_window_buttons"
     },
     "position": {
-        "message": "Position"
+        "message": "Posición"
     },
     "pressAnyKeyOrScroll": {
-        "message": "Press any key or use mouse wheel."
+        "message": "Aprieta una tecla o haz scroll"
     },
     "pressAnyKeyOrUseMouseWheel": {
-        "message": "Press any key or use mouse wheel"
+        "message": "Aprieta una tecla o usa la rueda del ratón"
     },
     "previousVideo": {
-        "message": "Previous video"
+        "message": "Reproducir video anterior"
     },
     "primaryColor": {
-        "message": "Primary color"
+        "message": "Color Primario"
     },
     "purple": {
-        "message": "Purple"
+        "message": "Morado"
     },
     "quality": {
-        "message": "Quality"
+        "message": "Calidad"
     },
     "raised": {
         "message": "Raised"
@@ -768,205 +768,205 @@
         "message": "RAM"
     },
     "rateMe": {
-        "message": "Rate me"
+        "message": "Califícame"
     },
     "rateUs": {
-        "message": "Rate us"
+        "message": "Califíquenos"
     },
     "red": {
-        "message": "Red"
+        "message": "Rojo"
     },
     "redDislikeButton": {
-        "message": "Show dislike button in red"
+        "message": "Mostrar el botón de dislike de color rojo"
     },
     "relatedVideos": {
-        "message": "Related videos"
+        "message": "Vídeos relacionados"
     },
     "remote": {
-        "message": "Play on TV"
+        "message": "Reproducir en el televisor"
     },
     "removeRelatedSearchResults": {
-        "message": "Remove related search results"
+        "message": "Quitar resultados relacionados"
     },
     "repeat": {
-        "message": "Repeat"
+        "message": "Repetir"
     },
     "report": {
         "message": "Report"
     },
     "reset": {
-        "message": "Reset"
+        "message": "Reiniciar"
     },
     "resetAllSettings": {
-        "message": "Reset all settings"
+        "message": "Restablecer todos los ajustes"
     },
     "resetAllShortcuts": {
-        "message": "Reset all shortcuts"
+        "message": "Restablecer todos los atajos"
     },
     "reverse": {
-        "message": "Reverse"
+        "message": "Revertir"
     },
     "rotate": {
-        "message": "Rotate"
+        "message": "Rotar"
     },
     "save": {
-        "message": "Save"
+        "message": "Guardar"
     },
     "saveAs": {
-        "message": "Save as"
+        "message": "Guardar como"
     },
     "schedule": {
-        "message": "Schedule"
+        "message": "Programar"
     },
     "screen": {
-        "message": "Screen"
+        "message": "Pantalla"
     },
     "screenshot": {
-        "message": "Screenshot"
+        "message": "Captura de pantalla"
     },
     "scrollBar": {
-        "message": "Scroll Bar"
+        "message": "Barra de desplazamiento"
     },
     "sd": {
         "message": "SD"
     },
     "search": {
-        "message": "Search"
+        "message": "Búsqueda"
     },
     "searchBarOnly": {
-        "message": "Search bar only"
+        "message": "Solo barra de búsqueda"
     },
     "seekBackward10Seconds": {
-        "message": "Seek backward 10 seconds"
+        "message": "Retroceder 10 segundos"
     },
     "seekForward10Seconds": {
-        "message": "Seek forward 10 seconds"
+        "message": "Adelantar 10 segundos"
     },
     "seekNextChapter": {
-        "message": "Seek Next Chapter"
+        "message": "Saltar al siguente capitulo"
     },
     "seekPreviousChapter": {
-        "message": "Seek Previous Chapter"
+        "message": "Saltar al capitulo anterior"
     },
     "settings": {
-        "message": "Settings"
+        "message": "Ajustes"
     },
     "settingsSuccessfullyImported": {
-        "message": "Settings successfully imported"
+        "message": "Ajustes importados correctamente"
     },
     "share": {
         "message": "Share"
     },
     "shortcuts": {
-        "message": "Shortcuts"
+        "message": "Atajos"
     },
     "showCardsOnMouseHover": {
-        "message": "Show cards on mouse hover"
+        "message": "Mostrar tarjetas al pasar el ratón"
     },
     "showChannelVideosCount": {
-        "message": "Show channel videos count"
+        "message": "Mostrar recuento de videos del canal"
     },
     "showLess": {
-        "message": "Show less"
+        "message": "Mostrar menos"
     },
     "showMore": {
-        "message": "Show more"
+        "message": "Mostrar mas"
     },
     "showRemainingDuration": {
-        "message": "Show video remaining duration"
+        "message": "Mostrar la duración restante del video"
     },
     "shuffle": {
-        "message": "Shuffle"
+        "message": "Aleatorio"
     },
     "sidebar": {
-        "message": "Sidebar"
+        "message": "Barra lateral"
     },
     "spacebar": {
-        "message": "Spacebar"
+        "message": "Espacio"
     },
     "squaredUserImages": {
-        "message": "Squared user images"
+        "message": "Fotos de perfil cuadradas"
     },
     "static": {
-        "message": "Static"
+        "message": "Estático"
     },
     "statsForNerds": {
-        "message": "Show Stats for Nerds"
+        "message": "Mostrar estadísticas para Nerds"
     },
     "step": {
-        "message": "Step"
+        "message": "Paso"
     },
     "stop": {
         "message": "Stop"
     },
     "style": {
-        "message": "Style"
+        "message": "Estilo"
     },
     "styles": {
-        "message": "Styles"
+        "message": "Estilos"
     },
     "subscribe": {
         "message": "Subscribe"
     },
     "subscriptions": {
-        "message": "Subscriptions"
+        "message": "Suscripciones"
     },
     "subtitles": {
-        "message": "Subtitles"
+        "message": "Subtítulos"
     },
     "sunset": {
-        "message": "Sunset"
+        "message": "Atardecer"
     },
     "sunsetToSunrise": {
-        "message": "Sunset to sunrise"
+        "message": "De atardecer a amanecer"
     },
     "systemPeferenceDark": {
-        "message": "System preference: dark"
+        "message": "Preferencia del sistema: Oscuro"
     },
     "systemPeferenceLight": {
-        "message": "System preference: light"
+        "message": "Preferencia del sistema: Claro"
     },
     "teal": {
-        "message": "Teal"
+        "message": "Verde azulado"
     },
     "textColor": {
-        "message": "Text color"
+        "message": "Color del texto"
     },
     "thanks": {
         "message": "Thanks"
     },
     "themes": {
-        "message": "Themes"
+        "message": "Temas"
     },
     "thisWillRemoveAllCookies": {
-        "message": "This will remove all cookies."
+        "message": "Esto borrará todas las cookies."
     },
     "thisWillRemoveAllWatchedVideos": {
         "message": "This will remove all watched videos."
     },
     "thisWillRemoveAllYouTubeCookies": {
-        "message": "This will remove all YouTube cookies"
+        "message": "Esto borrará todas las cookies de YouTube"
     },
     "thisWillResetAllSettings": {
-        "message": "This will reset all settings."
+        "message": "Esto restablecerá todos los ajustes"
     },
     "thisWillResetAllShortcuts": {
-        "message": "This will reset all shortcuts"
+        "message": "Esto restablecerá todos los atajos"
     },
     "thumbnails": {
-        "message": "Thumbnails"
+        "message": "Miniaturas"
     },
     "thumbnailsQuality": {
-        "message": "Thumbnails Quality"
+        "message": "Calidad de miniaturas"
     },
     "timeFrom": {
-        "message": "Time from"
+        "message": "Desde"
     },
     "timeTo": {
-        "message": "Time to"
+        "message": "Hasta"
     },
     "todayAt": {
-        "message": "Today at"
+        "message": "Hoy a las"
     },
     "toggleAutoplay": {
         "message": "Toggle autoplay"
@@ -975,7 +975,7 @@
         "message": "Toggle cards"
     },
     "toggleControls": {
-        "message": "Toggle player controls"
+        "message": "Toggle controls"
     },
     "topChat": {
         "message": "Top chat"
@@ -984,40 +984,40 @@
         "message": "Track watched videos"
     },
     "trailerAutoplay": {
-        "message": "Trailer autoplay"
+        "message": "Reproducción automática de trailer"
     },
     "translations": {
-        "message": "Translations"
+        "message": "Traducciones"
     },
     "transparentBackground": {
-        "message": "Transparent background"
+        "message": "Fondo transparente"
     },
     "trending": {
-        "message": "Trending"
+        "message": "Tendencias"
     },
     "tryToReloadThePage": {
-        "message": "Try to reload the page"
+        "message": "Intentar recargar la página"
     },
     "type": {
-        "message": "Type"
+        "message": "Tipo"
     },
     "upNextAutoplay": {
-        "message": "Up next autoplay"
+        "message": "Siguiente reproducción automática"
     },
     "use24HourFormat": {
-        "message": "Use 24-hour format"
+        "message": "Usar formato 24 horas"
     },
     "version": {
-        "message": "Version"
+        "message": "Versión"
     },
     "video": {
         "message": "Video"
     },
     "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "The video description will be expanded to get the name of the category"
+        "message": "La descripción del video se expandirá para obtener el nombre de la categoría."
     },
     "videoFormats": {
-        "message": "Video formats"
+        "message": "Formatos de video"
     },
     "videos": {
         "message": "Videos"
@@ -1026,45 +1026,45 @@
         "message": "View Mode"
     },
     "volume": {
-        "message": "Volume"
+        "message": "Volumen"
     },
     "watchLater": {
-        "message": "Watch later"
+        "message": "Ver más tarde"
     },
     "watchTime": {
-        "message": "Watch time"
+        "message": "Visualizaciones"
     },
     "whenPaused": {
         "message": "When paused"
     },
     "whenTabIsChanged": {
-        "message": "When tab is changed"
+        "message": "Al cambiar de pestaña"
     },
     "white": {
-        "message": "White"
+        "message": "Blanco"
     },
     "windowColor": {
         "message": "Window color"
     },
     "windowOpacity": {
-        "message": "Window opacity"
+        "message": "Opacidad de la ventana"
     },
     "yellow": {
-        "message": "Yellow"
+        "message": "Amarillo"
     },
     "youtubeHeaderLeft": {
-        "message": "YouTube Header (left)"
+        "message": "Encabezado YouTube (izq)"
     },
     "youtubeHeaderRight": {
-        "message": "YouTube Header (right)"
+        "message": "Encabezado YouTube (der)"
     },
     "youtubeHomePage": {
-        "message": "YouTube home page"
+        "message": "Página de inicio de YouTube"
     },
     "youtubeLanguage": {
-        "message": "YouTube language"
+        "message": "Idioma de YouTube"
     },
     "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limits video quality to 1080p for h.264 codec"
+        "message": "YouTube limita calidad de video a 1080p para el codec h.264"
     }
 }

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -1,0 +1,1070 @@
+{
+    "ARROWDOWN": {
+        "message": "⇩"
+    },
+    "ARROWLEFT": {
+        "message": "⇦"
+    },
+    "ARROWRIGHT": {
+        "message": "⇨"
+    },
+    "ARROWUP": {
+        "message": "⇧"
+    },
+    "about": {
+        "message": "About"
+    },
+    "accept": {
+        "message": "Accept"
+    },
+    "activate": {
+        "message": "Activate"
+    },
+    "activateCaptions": {
+        "message": "Activate captions"
+    },
+    "activateFullscreen": {
+        "message": "Activate fullscreen"
+    },
+    "activated": {
+        "message": "Activated"
+    },
+    "activatedFeatures": {
+        "message": "Activated features"
+    },
+    "activeFeatures": {
+        "message": "Active features"
+    },
+    "addScrollToTop": {
+        "message": "Add «Scroll to top»"
+    },
+    "ads": {
+        "message": "Ads"
+    },
+    "all": {
+        "message": "All"
+    },
+    "allow": {
+        "message": "Allow"
+    },
+    "allow60fps": {
+        "message": "Allow 60fps"
+    },
+    "always": {
+        "message": "Always"
+    },
+    "alwaysActive": {
+        "message": "Always active"
+    },
+    "alwaysShowProgressBar": {
+        "message": "Always show progress bar"
+    },
+    "amber": {
+        "message": "Amber"
+    },
+    "analyzer": {
+        "message": "Analyzer"
+    },
+    "appearance": {
+        "message": "Appearance"
+    },
+    "areYouSureYouWantToExportTheData": {
+        "message": "Are you sure you want to export the data?"
+    },
+    "areYouSureYouWantToImportTheData": {
+        "message": "Are you sure you want to import this data?"
+    },
+    "audio": {
+        "message": "Audio"
+    },
+    "audioFormats": {
+        "message": "Audio formats"
+    },
+    "auto": {
+        "message": "Auto"
+    },
+    "autoFullscreen": {
+        "message": "Auto-fullscreen"
+    },
+    "autopauseWhenSwitchingTabs": {
+        "message": "Autopause when switching tabs"
+    },
+    "autoplay": {
+        "message": "Autoplay"
+    },
+    "avoidAv1": {
+        "message": "Avoid AV1"
+    },
+    "avoidAv1Vp8Vp9": {
+        "message": "Avoid AV1, VP8, VP9"
+    },
+    "avoidAv1Vp9": {
+        "message": "Avoid AV1, VP9"
+    },
+    "avoidCpuRenderingWhenPossible": {
+        "message": "Avoid CPU rendering when possible"
+    },
+    "backgroundColor": {
+        "message": "Background color"
+    },
+    "backgroundOpacity": {
+        "message": "Background opacity"
+    },
+    "backupAndReset": {
+        "message": "Backup & reset"
+    },
+    "baseOnSystemColorScheme": {
+        "message": "Base on system color scheme"
+    },
+    "belowPlayer": {
+        "message": "Below player"
+    },
+    "black": {
+        "message": "Black"
+    },
+    "blacklist": {
+        "message": "Blacklist"
+    },
+    "blockAll": {
+        "message": "Block all"
+    },
+    "blockAv1": {
+        "message": "Block AV1"
+    },
+    "blockH264": {
+        "message": "Block H.264"
+    },
+    "blockMusic": {
+        "message": "Block music"
+    },
+    "blockVp8": {
+        "message": "Block VP8"
+    },
+    "blockVp9": {
+        "message": "Block VP9"
+    },
+    "blue": {
+        "message": "Blue"
+    },
+    "blueGray": {
+        "message": "Blue gray"
+    },
+    "bluelight": {
+        "message": "Bluelight"
+    },
+    "brown": {
+        "message": "Brown"
+    },
+    "browser": {
+        "message": "Browser"
+    },
+    "browserVersion": {
+        "message": "Browser version"
+    },
+    "bubbles": {
+        "message": "Bubbles"
+    },
+    "bug": {
+        "message": "Bug"
+    },
+    "buttons": {
+        "message": "Buttons"
+    },
+    "cancel": {
+        "message": "Cancel"
+    },
+    "categories": {
+        "message": "Categories"
+    },
+    "channel": {
+        "message": "Channel"
+    },
+    "channels": {
+        "message": "Channels"
+    },
+    "characterEdgeStyle": {
+        "message": "Character edge style"
+    },
+    "clip": {
+        "message": "Clip"
+    },
+    "clipboard": {
+        "message": "Clipboard"
+    },
+    "codecH264": {
+        "message": "Codec h.264"
+    },
+    "codecs": {
+        "message": "Codecs"
+    },
+    "collapseOfSubscriptionSections": {
+        "message": "Collapse of subscription sections"
+    },
+    "collapsed": {
+        "message": "Collapsed"
+    },
+    "comments": {
+        "message": "Comments"
+    },
+    "confirmationBeforeClosing": {
+        "message": "Confirmation before closing"
+    },
+    "cookies": {
+        "message": "Cookies"
+    },
+    "cores": {
+        "message": "Cores"
+    },
+    "cropChapterTitles": {
+        "message": "Crop chapter titles"
+    },
+    "custom": {
+        "message": "Custom"
+    },
+    "customCss": {
+        "message": "Custom CSS"
+    },
+    "customJs": {
+        "message": "Custom JS"
+    },
+    "customMiniPlayer": {
+        "message": "Custom Mini-Player"
+    },
+    "cyan": {
+        "message": "Cyan"
+    },
+    "dark": {
+        "message": "Dark"
+    },
+    "darkTheme": {
+        "message": "Dark theme"
+    },
+    "dateAndTime": {
+        "message": "Date & time"
+    },
+    "dawn": {
+        "message": "Dawn"
+    },
+    "decreasePlaybackSpeed": {
+        "message": "Decrease playback speed"
+    },
+    "decreaseVolume": {
+        "message": "Decrease volume"
+    },
+    "deepOrange": {
+        "message": "Deep orange"
+    },
+    "deepPurple": {
+        "message": "Deep purple"
+    },
+    "default": {
+        "message": "Default"
+    },
+    "defaultChannelTab": {
+        "message": "Default channel tab"
+    },
+    "defaultContentCountry": {
+        "message": "Default content country"
+    },
+    "deleteWatchedVideos": {
+        "message": "Delete watched videos"
+    },
+    "deleteYoutubeCookies": {
+        "message": "Delete YouTube cookies"
+    },
+    "depressed": {
+        "message": "Depressed"
+    },
+    "description": {
+        "message": "Description"
+    },
+    "description_ext": {
+        "message": "Make YouTube tidy+smart! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+    },
+    "desert": {
+        "message": "Desert"
+    },
+    "details": {
+        "message": "Details"
+    },
+    "developerOptions": {
+        "message": "Developer options"
+    },
+    "device": {
+        "message": "Device"
+    },
+    "dim": {
+        "message": "Dim"
+    },
+    "disabled": {
+        "message": "Disabled"
+    },
+    "dislike": {
+        "message": "Dislike"
+    },
+    "doNotChange": {
+        "message": "Don't change"
+    },
+    "donate": {
+        "message": "Donate"
+    },
+    "download": {
+        "message": "Download"
+    },
+    "draggable": {
+        "message": "Draggable"
+    },
+    "dropShadow": {
+        "message": "Drop shadow"
+    },
+    "durationWithSpeed": {
+        "message": "Show time remaining with reference to playback speed"
+    },
+    "email": {
+        "message": "Email"
+    },
+    "empty": {
+        "message": "Empty"
+    },
+    "enabled": {
+        "message": "Enabled"
+    },
+    "enabledForced": {
+        "message": "Enabled (forced)"
+    },
+    "expanded": {
+        "message": "Expanded"
+    },
+    "exportSettings": {
+        "message": "Export settings"
+    },
+    "extension": {
+        "message": "Extension"
+    },
+    "file": {
+        "message": "File"
+    },
+    "filters": {
+        "message": "Filters"
+    },
+    "fitToWindow": {
+        "message": "Fit to window"
+    },
+    "flash": {
+        "message": "Flash"
+    },
+    "font": {
+        "message": "Font"
+    },
+    "fontColor": {
+        "message": "Font color"
+    },
+    "fontFamily": {
+        "message": "Font family"
+    },
+    "fontOpacity": {
+        "message": "Font opacity"
+    },
+    "fontSize": {
+        "message": "Font size"
+    },
+    "footer": {
+        "message": "Footer"
+    },
+    "forceSDR": {
+        "message": "Force SDR"
+    },
+    "forcedPlayVideoFromTheBeginning": {
+        "message": "Force video to play from the beginning"
+    },
+    "forcedPlaybackSpeed": {
+        "message": "Forced playback speed"
+    },
+    "forcedTheaterMode": {
+        "message": "Forced theater mode"
+    },
+    "forcedVolume": {
+        "message": "Forced volume"
+    },
+    "foundABug": {
+        "message": "Found a bug?"
+    },
+    "fullWindow": {
+        "message": "Full window"
+    },
+    "general": {
+        "message": "General"
+    },
+    "geoPreference": {
+        "message": "Geo Preference"
+    },
+    "github": {
+        "message": "GitHub"
+    },
+    "goToSearchBox": {
+        "message": "Go to search box"
+    },
+    "googleApiKey": {
+        "message": "Google API key"
+    },
+    "gpu": {
+        "message": "GPU"
+    },
+    "green": {
+        "message": "Green"
+    },
+    "hd": {
+        "message": "HD"
+    },
+    "hdThumbnail": {
+        "message": "HD thumbnail"
+    },
+    "header": {
+        "message": "Header"
+    },
+    "hidden": {
+        "message": "Hidden"
+    },
+    "hiddenOnVideoPage": {
+        "message": "Hidden on video page"
+    },
+    "hideAnimatedThumbnails": {
+        "message": "Hide animated thumbnails"
+    },
+    "hideAnnotations": {
+        "message": "Hide annotations"
+    },
+    "hideButtonLabel": {
+        "message": "Hide Button Label"
+    },
+    "hideCards": {
+        "message": "Hide cards"
+    },
+    "hideCountryCode": {
+        "message": "Hide country code"
+    },
+    "hideDate": {
+        "message": "Hide date"
+    },
+    "hideDetailButton": {
+        "message": "Hide Detail Button"
+    },
+    "hideDetails": {
+        "message": "Hide details"
+    },
+    "hideEndscreen": {
+        "message": "Hide endscreen"
+    },
+    "hideFeaturedContent": {
+        "message": "Hide featured content"
+    },
+    "hideFooter": {
+        "message": "Hide footer"
+    },
+    "hideGradientBottom": {
+        "message": "Hide shadow around player-bar"
+    },
+    "hidePlayerControlsBar": {
+        "message": "Hide player controls bar"
+    },
+    "hidePlayerControlsBarButtons": {
+        "message": "Hide player controls     buttons"
+    },
+    "hidePlayerControlsBarOptions": {
+        "message": "Hide player controls options"
+    },
+    "hidePlaylist": {
+        "message": "Hide playlist"
+    },
+    "hideRightButtons": {
+        "message": "Hide right buttons"
+    },
+    "hideScrollForDetails": {
+        "message": "Hide «Scroll for details»"
+    },
+    "hideSkipOverlay": {
+        "message": "Hide 5 second skip animation"
+    },
+    "hideThumbnailOverlay": {
+        "message": "Hide buttons on thumbnails"
+    },
+    "hideThumbnails": {
+        "message": "Hide thumbnails"
+    },
+    "hideViewsCount": {
+        "message": "Hide views count"
+    },
+    "hideVoiceSearchButton": {
+        "message": "Hide voice search button"
+    },
+    "high": {
+        "message": "High"
+    },
+    "history": {
+        "message": "History"
+    },
+    "home": {
+        "message": "Home"
+    },
+    "hover": {
+        "message": "Hover"
+    },
+    "hoverOnVideoPage": {
+        "message": "Hover on video page"
+    },
+    "howLongAgoTheVideoWasUploaded": {
+        "message": "How long ago the video was uploaded"
+    },
+    "icons": {
+        "message": "Icons"
+    },
+    "iconsOnly": {
+        "message": "Icons only"
+    },
+    "importSettings": {
+        "message": "Import settings"
+    },
+    "improveLogo": {
+        "message": "Improve logo"
+    },
+    "improvedtubeButtons": {
+        "message": "ImprovedTube buttons"
+    },
+    "improvedtubeIconOnYoutube": {
+        "message": "ImprovedTube icon on YouTube"
+    },
+    "improvedtubeLanguage": {
+        "message": "ImprovedTube language"
+    },
+    "improvedtubeVersion": {
+        "message": "ImprovedTube version"
+    },
+    "increasePlaybackSpeed": {
+        "message": "Increase playback speed"
+    },
+    "increaseVolume": {
+        "message": "Increase volume"
+    },
+    "indigo": {
+        "message": "Indigo"
+    },
+    "items": {
+        "message": "Items"
+    },
+    "language": {
+        "message": "Language"
+    },
+    "languages": {
+        "message": "Languages"
+    },
+    "legacyYoutube": {
+        "message": "Legacy YouTube"
+    },
+    "library": {
+        "message": "Library"
+    },
+    "light": {
+        "message": "Light"
+    },
+    "lightBlue": {
+        "message": "Light blue"
+    },
+    "lightGreen": {
+        "message": "Light green"
+    },
+    "like": {
+        "message": "Like"
+    },
+    "likeAndDislike": {
+        "message": "Like and Dislike "
+    },
+    "liked": {
+        "message": "Liked"
+    },
+    "lime": {
+        "message": "Lime"
+    },
+    "limitPageWidth": {
+        "message": "Limit page width"
+    },
+    "list": {
+        "message": "List"
+    },
+    "liveChat": {
+        "message": "Live chat"
+    },
+    "liveChatType": {
+        "message": "Live chat type"
+    },
+    "location": {
+        "message": "Location"
+    },
+    "loop": {
+        "message": "Loop"
+    },
+    "loudnessNormalization": {
+        "message": "Loudness normalization"
+    },
+    "low": {
+        "message": "Low"
+    },
+    "markWatchedVideos": {
+        "message": "Mark watched videos"
+    },
+    "medium": {
+        "message": "Medium"
+    },
+    "mixer": {
+        "message": "Mixer"
+    },
+    "more": {
+        "message": "More"
+    },
+    "moveSidebarLeft": {
+        "message": "Move sidebar left"
+    },
+    "moveThumbnailsRight": {
+        "message": "Move thumbnails right"
+    },
+    "myColors": {
+        "message": "My colors"
+    },
+    "name": {
+        "message": "Name"
+    },
+    "nativeMiniPlayer": {
+        "message": "Native mini player"
+    },
+    "new": {
+        "message": "New"
+    },
+    "nextVideo": {
+        "message": "Next video"
+    },
+    "night": {
+        "message": "Night"
+    },
+    "noActiveFeatures": {
+        "message": "No active features"
+    },
+    "noOpenVideoTabs": {
+        "message": "No open video tabs"
+    },
+    "none": {
+        "message": "None"
+    },
+    "normal": {
+        "message": "Normal"
+    },
+    "off": {
+        "message": "Off"
+    },
+    "ok": {
+        "message": "Ok"
+    },
+    "old": {
+        "message": "Old"
+    },
+    "onAllVideos": {
+        "message": "On all videos"
+    },
+    "onSubscribedChannels": {
+        "message": "On subscribed channels"
+    },
+    "onlyActiveOnYoutube": {
+        "message": "Only active on YouTube"
+    },
+    "onlyOnePlayerInstancePlaying": {
+        "message": "Only one player instance playing"
+    },
+    "openPopupPlayer": {
+        "message": "Open video/playlist in a new window"
+    },
+    "orange": {
+        "message": "Orange"
+    },
+    "os": {
+        "message": "OS"
+    },
+    "other": {
+        "message": "Other"
+    },
+    "outline": {
+        "message": "Outline"
+    },
+    "overlay": {
+        "message": "Overlay"
+    },
+    "permissions": {
+        "message": "Permissions"
+    },
+    "pictureInPicture": {
+        "message": "Picture-in-Picture"
+    },
+    "pink": {
+        "message": "Pink"
+    },
+    "plain": {
+        "message": "Plain"
+    },
+    "platform": {
+        "message": "Platform"
+    },
+    "playAllButton": {
+        "message": "\"Play all\" button"
+    },
+    "playPause": {
+        "message": "Play / Pause"
+    },
+    "playbackSpeed": {
+        "message": "Playback speed"
+    },
+    "player": {
+        "message": "Player"
+    },
+    "playerColor": {
+        "message": "Player color"
+    },
+    "playerSize": {
+        "message": "Player size"
+    },
+    "playlist": {
+        "message": "Playlist"
+    },
+    "playlists": {
+        "message": "Playlists"
+    },
+    "popupPlayer": {
+        "message": "Popup player"
+    },
+    "popupWindowButtons": {
+        "message": "Add popup Window buttons"
+    },
+    "position": {
+        "message": "Position"
+    },
+    "pressAnyKeyOrScroll": {
+        "message": "Press any key or use mouse wheel."
+    },
+    "pressAnyKeyOrUseMouseWheel": {
+        "message": "Press any key or use mouse wheel"
+    },
+    "previousVideo": {
+        "message": "Previous video"
+    },
+    "primaryColor": {
+        "message": "Primary color"
+    },
+    "purple": {
+        "message": "Purple"
+    },
+    "quality": {
+        "message": "Quality"
+    },
+    "raised": {
+        "message": "Raised"
+    },
+    "ram": {
+        "message": "RAM"
+    },
+    "rateMe": {
+        "message": "Rate me"
+    },
+    "rateUs": {
+        "message": "Rate us"
+    },
+    "red": {
+        "message": "Red"
+    },
+    "redDislikeButton": {
+        "message": "Show dislike button in red"
+    },
+    "relatedVideos": {
+        "message": "Related videos"
+    },
+    "remote": {
+        "message": "Play on TV"
+    },
+    "removeRelatedSearchResults": {
+        "message": "Remove related search results"
+    },
+    "repeat": {
+        "message": "Repeat"
+    },
+    "report": {
+        "message": "Report"
+    },
+    "reset": {
+        "message": "Reset"
+    },
+    "resetAllSettings": {
+        "message": "Reset all settings"
+    },
+    "resetAllShortcuts": {
+        "message": "Reset all shortcuts"
+    },
+    "reverse": {
+        "message": "Reverse"
+    },
+    "rotate": {
+        "message": "Rotate"
+    },
+    "save": {
+        "message": "Save"
+    },
+    "saveAs": {
+        "message": "Save as"
+    },
+    "schedule": {
+        "message": "Schedule"
+    },
+    "screen": {
+        "message": "Screen"
+    },
+    "screenshot": {
+        "message": "Screenshot"
+    },
+    "scrollBar": {
+        "message": "Scroll Bar"
+    },
+    "sd": {
+        "message": "SD"
+    },
+    "search": {
+        "message": "Search"
+    },
+    "searchBarOnly": {
+        "message": "Search bar only"
+    },
+    "seekBackward10Seconds": {
+        "message": "Seek backward 10 seconds"
+    },
+    "seekForward10Seconds": {
+        "message": "Seek forward 10 seconds"
+    },
+    "seekNextChapter": {
+        "message": "Seek Next Chapter"
+    },
+    "seekPreviousChapter": {
+        "message": "Seek Previous Chapter"
+    },
+    "settings": {
+        "message": "Settings"
+    },
+    "settingsSuccessfullyImported": {
+        "message": "Settings successfully imported"
+    },
+    "share": {
+        "message": "Share"
+    },
+    "shortcuts": {
+        "message": "Shortcuts"
+    },
+    "showCardsOnMouseHover": {
+        "message": "Show cards on mouse hover"
+    },
+    "showChannelVideosCount": {
+        "message": "Show channel videos count"
+    },
+    "showLess": {
+        "message": "Show less"
+    },
+    "showMore": {
+        "message": "Show more"
+    },
+    "showRemainingDuration": {
+        "message": "Show video remaining duration"
+    },
+    "shuffle": {
+        "message": "Shuffle"
+    },
+    "sidebar": {
+        "message": "Sidebar"
+    },
+    "spacebar": {
+        "message": "Spacebar"
+    },
+    "squaredUserImages": {
+        "message": "Squared user images"
+    },
+    "static": {
+        "message": "Static"
+    },
+    "statsForNerds": {
+        "message": "Show Stats for Nerds"
+    },
+    "step": {
+        "message": "Step"
+    },
+    "stop": {
+        "message": "Stop"
+    },
+    "style": {
+        "message": "Style"
+    },
+    "styles": {
+        "message": "Styles"
+    },
+    "subscribe": {
+        "message": "Subscribe"
+    },
+    "subscriptions": {
+        "message": "Subscriptions"
+    },
+    "subtitles": {
+        "message": "Subtitles"
+    },
+    "sunset": {
+        "message": "Sunset"
+    },
+    "sunsetToSunrise": {
+        "message": "Sunset to sunrise"
+    },
+    "systemPeferenceDark": {
+        "message": "System preference: dark"
+    },
+    "systemPeferenceLight": {
+        "message": "System preference: light"
+    },
+    "teal": {
+        "message": "Teal"
+    },
+    "textColor": {
+        "message": "Text color"
+    },
+    "thanks": {
+        "message": "Thanks"
+    },
+    "themes": {
+        "message": "Themes"
+    },
+    "thisWillRemoveAllCookies": {
+        "message": "This will remove all cookies."
+    },
+    "thisWillRemoveAllWatchedVideos": {
+        "message": "This will remove all watched videos."
+    },
+    "thisWillRemoveAllYouTubeCookies": {
+        "message": "This will remove all YouTube cookies"
+    },
+    "thisWillResetAllSettings": {
+        "message": "This will reset all settings."
+    },
+    "thisWillResetAllShortcuts": {
+        "message": "This will reset all shortcuts"
+    },
+    "thumbnails": {
+        "message": "Thumbnails"
+    },
+    "thumbnailsQuality": {
+        "message": "Thumbnails Quality"
+    },
+    "timeFrom": {
+        "message": "Time from"
+    },
+    "timeTo": {
+        "message": "Time to"
+    },
+    "todayAt": {
+        "message": "Today at"
+    },
+    "toggleAutoplay": {
+        "message": "Toggle autoplay"
+    },
+    "toggleCards": {
+        "message": "Toggle cards"
+    },
+    "toggleControls": {
+        "message": "Toggle player controls"
+    },
+    "topChat": {
+        "message": "Top chat"
+    },
+    "trackWatchedVideos": {
+        "message": "Track watched videos"
+    },
+    "trailerAutoplay": {
+        "message": "Trailer autoplay"
+    },
+    "translations": {
+        "message": "Translations"
+    },
+    "transparentBackground": {
+        "message": "Transparent background"
+    },
+    "trending": {
+        "message": "Trending"
+    },
+    "tryToReloadThePage": {
+        "message": "Try to reload the page"
+    },
+    "type": {
+        "message": "Type"
+    },
+    "upNextAutoplay": {
+        "message": "Up next autoplay"
+    },
+    "use24HourFormat": {
+        "message": "Use 24-hour format"
+    },
+    "version": {
+        "message": "Version"
+    },
+    "video": {
+        "message": "Video"
+    },
+    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
+        "message": "The video description will be expanded to get the name of the category"
+    },
+    "videoFormats": {
+        "message": "Video formats"
+    },
+    "videos": {
+        "message": "Videos"
+    },
+    "viewMode": {
+        "message": "View Mode"
+    },
+    "volume": {
+        "message": "Volume"
+    },
+    "watchLater": {
+        "message": "Watch later"
+    },
+    "watchTime": {
+        "message": "Watch time"
+    },
+    "whenPaused": {
+        "message": "When paused"
+    },
+    "whenTabIsChanged": {
+        "message": "When tab is changed"
+    },
+    "white": {
+        "message": "White"
+    },
+    "windowColor": {
+        "message": "Window color"
+    },
+    "windowOpacity": {
+        "message": "Window opacity"
+    },
+    "yellow": {
+        "message": "Yellow"
+    },
+    "youtubeHeaderLeft": {
+        "message": "YouTube Header (left)"
+    },
+    "youtubeHeaderRight": {
+        "message": "YouTube Header (right)"
+    },
+    "youtubeHomePage": {
+        "message": "YouTube home page"
+    },
+    "youtubeLanguage": {
+        "message": "YouTube language"
+    },
+    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
+        "message": "YouTube limits video quality to 1080p for h.264 codec"
+    }
+}


### PR DESCRIPTION
Instead of deleting the untranslated es_419, I replaced it with es so that users with es_419 will see the translated text and in the future a translator can update it to better fall in line with es_419.